### PR TITLE
refactor type aliases and traits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-
+# Rust
 /target
 **/*.rs.bk
 Cargo.lock
+
+# Markdown preview
+.markdown-preview.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,15 @@ rust:
 script:
   - cargo build --verbose
   - cargo test  --verbose
-  - cargo doc   --verbose
+  - cargo rustdoc --verbose -- --html-in-header rustdoc-include-katex-header.html
 matrix:
   fast_failures: true
   allow_failures:
     - env: KCOV=1
   include:
-    - rust: nightly-2018-03-06
+    - rust: nightly-2018-04-02
       env:
-        - CLIPPY_VERSION=0.0.187
+        - CLIPPY_VERSION=0.0.191
       before_script:
         - cargo install rustfmt-nightly --force
         - cargo install clippy --version $CLIPPY_VERSION || echo "clippy already installed"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
 script:
   - cargo build --verbose
   - cargo test  --verbose
-  - cargo rustdoc --verbose -- --html-in-header rustdoc-include-katex-header.html
+  - cargo rustdoc --verbose
 matrix:
   fast_failures: true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ matrix:
   allow_failures:
     - env: KCOV=1
   include:
-    - rust: nightly-2018-04-02
+    - rust: nightly-2018-04-11
       env:
-        - CLIPPY_VERSION=0.0.191
+        - CLIPPY_VERSION=0.0.193
       before_script:
         - cargo install rustfmt-nightly --force
         - cargo install clippy --version $CLIPPY_VERSION || echo "clippy already installed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ categories = ["science", "data-structures", "algorithms", "parser-implementation
 
 [dependencies]
 nom = "4.0.0-beta2"
+itertools = "0.7.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,10 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/joshrule/term-rewriting-rs"
 homepage = "https://github.com/joshrule/term-rewriting-rs"
-description = "An implementation of first-order term rewriting systems (TRS)"
-keywords = ["term-rewriting", "language", "rewriting"]
-categories = ["science", "data-structures", "algorithms"]
+documentation = "https://docs.rs/polytype"
+description = "A Rust library for representing and parsing first-order term rewriting systems."
+keywords = ["term-rewriting", "language", "rewriting", "parser"]
+categories = ["science", "data-structures", "algorithms", "parser implementations", "science"]
 
 [dependencies]
 nom = "4.0.0-beta2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/joshrule/term-rewriting-rs"
 homepage = "https://github.com/joshrule/term-rewriting-rs"
-documentation = "https://docs.rs/polytype"
+documentation = "https://docs.rs/term_rewriting"
 description = "A Rust library for representing and parsing first-order term rewriting systems."
 keywords = ["term-rewriting", "language", "rewriting", "parser"]
-categories = ["science", "data-structures", "algorithms", "parser implementations", "science"]
+categories = ["science", "data-structures", "algorithms", "parser-implementations"]
 
 [dependencies]
 nom = "4.0.0-beta2"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Status](https://travis-ci.org/joshrule/term-rewriting-rs.svg?branch=develop)](ht
 
 # [term-rewriting-rs][0]
 
-A [Rust][1] library for parsing, representing, and computing with first-order [term rewriting systems][2].
+A [Rust][1] library for representing and parsing first-order [term rewriting systems][2].
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-[![Build
-Status](https://travis-ci.org/joshrule/term-rewriting-rs.svg?branch=develop)](https://travis-ci.org/joshrule/term-rewriting-rs)
-
 # [term-rewriting-rs][0]
+
+[![Travis-CI.org](https://img.shields.io/travis/joshrule/term-rewriting-rs.svg?maxAge=3600)](https://travis-ci.org/joshrule/term-rewriting-rs)
+[![Crates.io](https://img.shields.io/crates/v/term_rewriting.svg?maxAge=3600)](https://crates.io/crates/term_rewriting)
+[![Codecov](https://img.shields.io/codecov/c/github/joshrule/term-rewriting-rs.svg?maxAge=3600)](https://codecov.io/gh/joshrule/term-rewriting-rs)
+[![docs.rs](https://docs.rs/term_rewriting/badge.svg)](https://docs.rs/term_rewriting)
 
 A [Rust][1] library for representing and parsing first-order [term rewriting systems][2].
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build
-Status](https://travis-ci.org/joshrule/term-rewriting-rs.svg?branch=setup_travis_ci)](https://travis-ci.org/joshrule/term-rewriting-rs)
+Status](https://travis-ci.org/joshrule/term-rewriting-rs.svg?branch=develop)](https://travis-ci.org/joshrule/term-rewriting-rs)
 
 # [term-rewriting-rs][0]
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To include as a dependency:
 
 ```toml
 [dependencies]
-term-rewriting = { git = "https://github.com/joshrule/term-rewriting-rs" }
+term-rewriting = "0.1"
 ```
 
 To actually make use of the library:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! A library for parsing and representing first-order [term rewriting systems][1].
+//! A [Rust][0] library for representing and parsing first-order [term rewriting systems][1].
 //!
 //! # Example
 //!
@@ -90,6 +90,8 @@
 //! - Bezem, Klop, & de Vrijer (Eds.) (2003). [Term Rewriting Systems][3]. Cambridge University Press.
 //! - [Rewriting][4]. (2017). Wikipedia.
 //!
+//! [0]: https://www.rust-lang.org
+//!      "The Rust Programming Language"
 //! [1]: https://en.wikipedia.org/wiki/Rewriting#Term_rewriting_systems
 //!      "Wikipedia - Term Rewriting Systems"
 //! [2]: http://www.cambridge.org/us/academic/subjects/computer-science/programming-languages-and-applied-logic/term-rewriting-and-all

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@
 
 #[macro_use]
 extern crate nom;
+extern crate itertools;
 
 mod parser;
 pub mod types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,20 +7,16 @@
 //! use term_rewriting::types::*;
 //!
 //! # fn main() {
-//! // A string representation of SK combinatory logic, including:
-//!
-//! // a rule for the S combinator,
-//! let s_rule = "S x_ y_ z_ = (x_ z_) (y_ z_);".to_string();
-//!
-//! // the rule for the K combinator,
-//! let k_rule = "K x_ y_ = x_;";
-//!
-//! // and an arbitrary term,
-//! let term = "S K K (K S K);";
-//!
-//! // can be parsed to give back the TRS and a term.
+//! // Given a signature,
 //! let mut sig = Signature::default();
-//! let (parsed_trs, parsed_term_vec) = sig.parse(&(s_rule + k_rule + term)).expect("successful parse");
+//!
+//! // we can parse a string representation of SK combinatory logic,
+//! let sk_rules = "S x_ y_ z_ = (x_ z_) (y_ z_); K x_ y_ = x_;";
+//! let parsed_trs = sig.parse_trs(sk_rules).expect("parsed TRS");
+//!
+//! // and we can also parse an arbitrary term.
+//! let term = "S K K (K S K)";
+//! let parsed_term = sig.parse_term(term).expect("parsed term");
 //!
 //! // These can also be constructed by hand. Let's look at the term:
 //! let mut sig = Signature::default();
@@ -28,7 +24,7 @@
 //! let s = sig.get_op("S", 0);
 //! let k = sig.get_op("K", 0);
 //!
-//! let term = Term::Application {
+//! let constructed_term = Term::Application {
 //!     head: app.clone(),
 //!     args: vec![
 //!         Term::Application {
@@ -60,10 +56,8 @@
 //!     ]
 //! };
 //!
-//! let constructed_term_vec = vec![term];
-//!
 //! // This is the same output the parser produces.
-//! assert_eq!(parsed_term_vec, constructed_term_vec);
+//! assert_eq!(parsed_term, constructed_term);
 //! # }
 //! ```
 //!

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -38,9 +38,7 @@ pub fn parse<'a>(input: &'a str, sig: &mut Signature) -> Result<(TRS, Vec<Term>)
 
             Ok((TRS::new(rs), ts))
         }
-        Ok((CompleteStr(_), _)) => {
-            Err("parse incomplete!")
-        }
+        Ok((CompleteStr(_), _)) => Err("parse incomplete!"),
         Err(_) => Err("parse failed!"),
     }
 }
@@ -158,8 +156,10 @@ impl<'a> Parser<'a> {
             do_parse!(term: call_m!(self.top_term) >>
                       (Statement::Term(term))));
 
-    method!(comment<Parser<'a>, CompleteStr, CompleteStr>, self,
-            preceded!(tag!("#"), take_until_and_consume!("\n"))
+    method!(
+        comment<Parser<'a>, CompleteStr, CompleteStr>,
+        self,
+        preceded!(tag!("#"), take_until_and_consume!("\n"))
     );
 
     method!(program<Parser<'a>, CompleteStr, Vec<Statement>>, mut self,
@@ -347,12 +347,21 @@ mod tests {
                         Term::Application {
                             head: app.clone(),
                             args: vec![
-                                Term::Application { head: s.clone(), args: vec![] },
-                                Term::Application { head: k.clone(), args: vec![] },
-                            ]
+                                Term::Application {
+                                    head: s.clone(),
+                                    args: vec![],
+                                },
+                                Term::Application {
+                                    head: k.clone(),
+                                    args: vec![],
+                                },
+                            ],
                         },
-                        Term::Application { head: k.clone(), args: vec![] }
-                    ]
+                        Term::Application {
+                            head: k.clone(),
+                            args: vec![],
+                        },
+                    ],
                 },
                 Term::Application {
                     head: app.clone(),
@@ -360,14 +369,23 @@ mod tests {
                         Term::Application {
                             head: app.clone(),
                             args: vec![
-                                Term::Application { head: k.clone(), args: vec![] },
-                                Term::Application { head: s.clone(), args: vec![] },
-                            ]
+                                Term::Application {
+                                    head: k.clone(),
+                                    args: vec![],
+                                },
+                                Term::Application {
+                                    head: s.clone(),
+                                    args: vec![],
+                                },
+                            ],
                         },
-                        Term::Application { head: k.clone(), args: vec![] }
-                    ]
-                }
-            ]
+                        Term::Application {
+                            head: k.clone(),
+                            args: vec![],
+                        },
+                    ],
+                },
+            ],
         };
 
         let term_vec = vec![term];
@@ -452,7 +470,9 @@ mod tests {
     #[test]
     fn parser_debug() {
         let mut sig = Signature::default();
-        let p = Parser { signature: &mut sig };
+        let p = Parser {
+            signature: &mut sig,
+        };
         assert_eq!(format!("{:?}", p),
                    "Parser { signature: Signature { operators: [], variables: [], operator_count: 0, variable_count: 0 } }");
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,7 +1,7 @@
 use super::types::*;
 
-use nom::{alphanumeric, multispace, IResult};
 use nom::types::CompleteStr;
+use nom::{alphanumeric, multispace, IResult};
 
 named!(lparen<CompleteStr, CompleteStr>,     tag!("("));
 named!(rparen<CompleteStr, CompleteStr>,     tag!(")"));
@@ -405,12 +405,10 @@ mod tests {
             head: a,
             args: vec![],
         };
-        let rhs = vec![
-            Term::Application {
-                head: b,
-                args: vec![],
-            },
-        ];
+        let rhs = vec![Term::Application {
+            head: b,
+            args: vec![],
+        }];
         let rule = Statement::Rule(Rule::new(lhs, rhs).unwrap());
 
         assert_eq!(parsed_rule, Ok((CompleteStr(""), rule)));

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -407,8 +407,20 @@ impl Signature {
     /// [`Term`]: enum.Term.html
     /// [`Ok((trs, terms))`]:  https://doc.rust-lang.org/std/result/enum.Result.html#variant.Ok
     /// [`Err`]:  https://doc.rust-lang.org/std/result/enum.Result.html#variant.Err
-    pub fn parse<'a>(&mut self, input: &'a str) -> Result<(TRS, Vec<Term>), &'a str> {
+    pub fn parse(&mut self, input: &str) -> Result<(TRS, Vec<Term>), parser::ParseError> {
         parser::parse(input, self)
+    }
+    /// Similar to `parse`, but produces only a [`TRS`].
+    ///
+    /// [`TRS`]: struct.TRS.html
+    pub fn parse_trs(&mut self, input: &str) -> Result<TRS, parser::ParseError> {
+        parser::parse_trs(input, self)
+    }
+    /// Similar to `parse`, but produces only a [`Term`].
+    ///
+    /// [`Term`]: struct.Term.html
+    pub fn parse_term(&mut self, input: &str) -> Result<Term, parser::ParseError> {
+        parser::parse_term(input, self)
     }
 }
 impl Default for Signature {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 
 use super::parser;
@@ -107,8 +108,6 @@ impl Term {
     }
 }
 
-use std::collections::HashSet;
-
 /// Represents a rewrite rule equating a left-hand-side [`Term`] with one or
 /// more right-hand-side [`Term`]s.
 ///
@@ -131,7 +130,6 @@ impl Rule {
             false
         }
     }
-
     /// Construct a rewrite rule from a left-hand-side (LHS) [`Term`] with one
     /// or more right-hand-side (RHS) [`Term`]s. Returns [`Some(Rule{lhs, rhs})`]
     /// if `Rule{lhs, rhs}` is valid, and [`None`] otherwise.
@@ -313,7 +311,7 @@ impl Default for Signature {
 }
 
 /// Represents a first-order term rewriting system.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct TRS {
     rules: Vec<Rule>,
 }
@@ -323,3 +321,6 @@ impl TRS {
         TRS { rules }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 
 use super::parser;
@@ -104,6 +104,20 @@ impl Term {
         match *self {
             Term::Variable(ref v) => vec![v],
             Term::Application { args: ref a, .. } => a.iter().flat_map(|x| x.variables()).collect(),
+        }
+    }
+    /// Given a mapping from [`Variable`s] to [`Term`s], perform a substitution on a [`Term`].
+    ///
+    /// [`Variable`s]: struct.Variable.html
+    /// [`Term`s]: enum.Term.html
+    /// [`Term`]: enum.Term.html
+    pub fn substitute(&self, sub: &HashMap<Variable, Term>) -> Term {
+        match *self {
+            Term::Variable(ref v) => sub.get(v).unwrap_or(self).clone(),
+            Term::Application { ref head, ref args } => Term::Application {
+                head: head.clone(),
+                args: args.iter().map(|x| x.substitute(sub)).collect(),
+            },
         }
     }
 }

--- a/src/types/tests.rs
+++ b/src/types/tests.rs
@@ -321,3 +321,83 @@ fn trs_debug() {
     let trs = TRS::new(vec![]);
     assert_eq!(format!("{:?}", trs), "TRS { rules: [] }");
 }
+
+#[test]
+fn unify_test() {
+    let mut sig = Signature::default();
+    let y = sig.get_var("y");
+    let z = sig.get_var("z");
+    let s = sig.get_op("S", 0);
+    let k = sig.get_op("K", 0);
+
+    // build a term
+    let s_t1 = "S K y_ z_;";
+    let (_, terms) = sig.parse(s_t1).expect("parse of S K y_ z_");
+    let t1 = terms[0].clone();
+
+    // build another term
+    let s_t2 = "S K S K;";
+    let (_, terms) = sig.parse(s_t2).expect("parse of S K S K");
+    let t2 = terms[0].clone();
+
+    // build another term
+    let s_t3 = "K K K K;";
+    let (_, terms) = sig.parse(s_t3).expect("parse of K K K K");
+    let t3 = terms[0].clone();
+
+    let mut hm1 = HashMap::new();
+    hm1.insert(
+        y.clone(),
+        Term::Application {
+            head: s.clone(),
+            args: vec![],
+        },
+    );
+    hm1.insert(
+        z.clone(),
+        Term::Application {
+            head: k.clone(),
+            args: vec![],
+        },
+    );
+    assert_eq!(Some(hm1), Term::unify(vec![(t1.clone(), t2.clone())]));
+    assert_eq!(None, Term::unify(vec![(t1.clone(), t3.clone())]));
+    assert_eq!(None, Term::unify(vec![(t2.clone(), t3.clone())]));
+
+    // build another term
+    let mut sig = Signature::default();
+    let y = sig.get_var("y");
+    let k = sig.get_op("K", 0);
+    let a = sig.get_op(".", 2);
+    let s_t4 = "y_ K;";
+    let (_, terms) = sig.parse(s_t4).expect("parse of y_ K");
+    let t4 = terms[0].clone();
+
+    let mut hm2 = HashMap::new();
+    hm2.insert(
+        y.clone(),
+        Term::Application {
+            head: a.clone(),
+            args: vec![
+                Term::Application {
+                    head: a.clone(),
+                    args: vec![
+                        Term::Application {
+                            head: k.clone(),
+                            args: vec![],
+                        },
+                        Term::Application {
+                            head: k.clone(),
+                            args: vec![],
+                        },
+                    ],
+                },
+                Term::Application {
+                    head: k.clone(),
+                    args: vec![],
+                },
+            ],
+        },
+    );
+    assert_eq!(Some(hm2), Term::unify(vec![(t3.clone(), t4.clone())]));
+}

--- a/src/types/tests.rs
+++ b/src/types/tests.rs
@@ -1,0 +1,281 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hash;
+use super::*;
+
+#[test]
+fn variable_name() {
+    let v1 = Variable { id: 7, name: None };
+    let v2 = Variable {
+        id: 8,
+        name: Some("blah".to_string()),
+    };
+
+    assert_eq!(v1.name(), &None);
+    assert_ne!(v1.name(), &Some("blah".to_string()));
+    assert_ne!(v2.name(), &None);
+    assert_eq!(v2.name(), &Some("blah".to_string()));
+}
+#[test]
+fn variable_eq() {
+    let v1 = Variable { id: 7, name: None };
+    let v2 = Variable { id: 8, name: None };
+    let v3 = Variable {
+        id: 7,
+        name: Some("blah".to_string()),
+    };
+    let v4 = Variable { id: 7, name: None };
+
+    assert_eq!(v1, v1);
+    assert_ne!(v1, v2);
+    assert_eq!(v1, v3);
+    assert_eq!(v1, v4);
+}
+#[test]
+fn variable_hash_eq() {
+    let mut hasher1 = DefaultHasher::new();
+    let mut hasher2 = DefaultHasher::new();
+    let v = Variable { id: 7, name: None };
+    7_usize.hash(&mut hasher1);
+    v.hash(&mut hasher2);
+
+    assert_eq!(hasher1.finish(), hasher2.finish());
+}
+#[test]
+fn variable_hash_ne() {
+    let mut hasher1 = DefaultHasher::new();
+    let mut hasher2 = DefaultHasher::new();
+    let v = Variable { id: 7, name: None };
+    8_usize.hash(&mut hasher1);
+    v.hash(&mut hasher2);
+
+    assert_ne!(hasher1.finish(), hasher2.finish());
+}
+
+#[test]
+fn rule_is_valid_yes() {
+    let lhs = Term::Application {
+        head: Operator {
+            arity: 0,
+            id: 0,
+            name: None,
+        },
+        args: vec![],
+    };
+
+    let rhs = vec![
+        Term::Application {
+            head: Operator {
+                arity: 0,
+                id: 1,
+                name: None,
+            },
+            args: vec![],
+        },
+    ];
+
+    assert!(Rule::is_valid(&lhs, &rhs));
+}
+#[test]
+fn rule_is_valid_lhs_var() {
+    let lhs = Term::Variable(Variable { name: None, id: 0 });
+
+    let rhs = vec![
+        Term::Application {
+            head: Operator {
+                arity: 0,
+                id: 1,
+                name: None,
+            },
+            args: vec![],
+        },
+    ];
+
+    assert!(!Rule::is_valid(&lhs, &rhs));
+}
+#[test]
+fn rule_is_valid_rhs_var() {
+    let lhs = Term::Application {
+        head: Operator {
+            arity: 0,
+            id: 0,
+            name: None,
+        },
+        args: vec![],
+    };
+
+    let rhs = vec![Term::Variable(Variable { name: None, id: 0 })];
+
+    assert!(!Rule::is_valid(&lhs, &rhs));
+}
+#[test]
+fn rule_new_some() {
+    let lhs = Term::Application {
+        head: Operator {
+            arity: 0,
+            id: 0,
+            name: None,
+        },
+        args: vec![],
+    };
+
+    let rhs = vec![
+        Term::Application {
+            head: Operator {
+                arity: 0,
+                id: 1,
+                name: None,
+            },
+            args: vec![],
+        },
+    ];
+
+    let rule = Rule {
+        lhs: lhs.clone(),
+        rhs: rhs.clone(),
+    };
+
+    assert_eq!(Rule::new(lhs, rhs), Some(rule));
+}
+#[test]
+fn rule_is_valid_none() {
+    let lhs = Term::Application {
+        head: Operator {
+            arity: 0,
+            id: 0,
+            name: None,
+        },
+        args: vec![],
+    };
+
+    let rhs = vec![Term::Variable(Variable { name: None, id: 0 })];
+
+    assert_eq!(Rule::new(lhs, rhs), None);
+}
+
+#[test]
+fn signature_debug() {
+    let sig = Signature::default();
+    assert_eq!(
+        format!("{:?}", sig),
+        "Signature { operators: [], variables: [], operator_count: 0, variable_count: 0 }"
+    );
+}
+#[test]
+fn signature_parse() {
+    let mut sig = Signature::default();
+    let sk = "S x_ y_ z_ = x_ z_ (y_ z_); K x_ y_ = x_;";
+
+    let a = Operator {
+        id: 0,
+        name: Some(".".to_string()),
+        arity: 2,
+    };
+    let s = Operator {
+        id: 1,
+        name: Some("S".to_string()),
+        arity: 0,
+    };
+    let k = Operator {
+        id: 2,
+        name: Some("K".to_string()),
+        arity: 0,
+    };
+    let x = Variable {
+        id: 0,
+        name: Some("x".to_string()),
+    };
+    let y = Variable {
+        id: 1,
+        name: Some("y".to_string()),
+    };
+    let z = Variable {
+        id: 2,
+        name: Some("z".to_string()),
+    };
+    let x2 = Variable {
+        id: 3,
+        name: Some("x".to_string()),
+    };
+    let y2 = Variable {
+        id: 4,
+        name: Some("y".to_string()),
+    };
+
+    let (trs1, _) = sig.parse(sk).expect("parse of SK");
+
+    let s_lhs = Term::Application {
+        head: a.clone(),
+        args: vec![
+            Term::Application {
+                head: a.clone(),
+                args: vec![
+                    Term::Application {
+                        head: a.clone(),
+                        args: vec![
+                            Term::Application {
+                                head: s.clone(),
+                                args: vec![],
+                            },
+                            Term::Variable(x.clone()),
+                        ],
+                    },
+                    Term::Variable(y.clone()),
+                ],
+            },
+            Term::Variable(z.clone()),
+        ],
+    };
+    let s_rhs = vec![
+        Term::Application {
+            head: a.clone(),
+            args: vec![
+                Term::Application {
+                    head: a.clone(),
+                    args: vec![Term::Variable(x.clone()), Term::Variable(z.clone())],
+                },
+                Term::Application {
+                    head: a.clone(),
+                    args: vec![Term::Variable(y.clone()), Term::Variable(z.clone())],
+                },
+            ],
+        },
+    ];
+    let s_rule = Rule::new(s_lhs, s_rhs).expect("new S rule");
+
+    let k_lhs = Term::Application {
+        head: a.clone(),
+        args: vec![
+            Term::Application {
+                head: a.clone(),
+                args: vec![
+                    Term::Application {
+                        head: k.clone(),
+                        args: vec![],
+                    },
+                    Term::Variable(x2.clone()),
+                ],
+            },
+            Term::Variable(y2.clone()),
+        ],
+    };
+    let k_rhs = vec![Term::Variable(x2.clone())];
+    let k_rule = Rule::new(k_lhs, k_rhs).expect("new K rule");
+
+    let trs2 = TRS {
+        rules: vec![s_rule, k_rule],
+    };
+
+    assert_eq!(trs1, trs2);
+}
+
+#[test]
+fn trs_new() {
+    let trs1 = TRS::new(vec![]);
+    let trs2 = TRS { rules: vec![] };
+    assert_eq!(trs1, trs2);
+}
+#[test]
+fn trs_debug() {
+    let trs = TRS::new(vec![]);
+    assert_eq!(format!("{:?}", trs), "TRS { rules: [] }");
+}

--- a/src/types/tests.rs
+++ b/src/types/tests.rs
@@ -325,10 +325,6 @@ fn trs_debug() {
 #[test]
 fn unify_test() {
     let mut sig = Signature::default();
-    let y = sig.get_var("y");
-    let z = sig.get_var("z");
-    let s = sig.get_op("S", 0);
-    let k = sig.get_op("K", 0);
 
     // build a term
     let s_t1 = "S K y_ z_;";
@@ -344,6 +340,17 @@ fn unify_test() {
     let s_t3 = "K K K K;";
     let (_, terms) = sig.parse(s_t3).expect("parse of K K K K");
     let t3 = terms[0].clone();
+
+    // build another term
+    let mut sig = Signature::default();
+    let y = sig.get_var("y");
+    let z = sig.get_var("z");
+    let a = sig.get_op(".", 2);
+    let s = sig.get_op("S", 0);
+    let k = sig.get_op("K", 0);
+    let s_t4 = "y_ K;";
+    let (_, terms) = sig.parse(s_t4).expect("parse of y_ K");
+    let t4 = terms[0].clone();
 
     let mut hm1 = HashMap::new();
     hm1.insert(
@@ -363,16 +370,6 @@ fn unify_test() {
     assert_eq!(Some(hm1), Term::unify(vec![(t1.clone(), t2.clone())]));
     assert_eq!(None, Term::unify(vec![(t1.clone(), t3.clone())]));
     assert_eq!(None, Term::unify(vec![(t2.clone(), t3.clone())]));
-
-    // build another term
-    let mut sig = Signature::default();
-    let y = sig.get_var("y");
-    let k = sig.get_op("K", 0);
-    let a = sig.get_op(".", 2);
-    let s_t4 = "y_ K;";
-    let (_, terms) = sig.parse(s_t4).expect("parse of y_ K");
-    let t4 = terms[0].clone();
-
     let mut hm2 = HashMap::new();
     hm2.insert(
         y.clone(),

--- a/src/types/tests.rs
+++ b/src/types/tests.rs
@@ -1,6 +1,6 @@
+use super::*;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hash;
-use super::*;
 
 #[test]
 fn term_substitute_test() {
@@ -104,16 +104,14 @@ fn rule_is_valid_yes() {
         args: vec![],
     };
 
-    let rhs = vec![
-        Term::Application {
-            head: Operator {
-                arity: 0,
-                id: 1,
-                name: None,
-            },
-            args: vec![],
+    let rhs = vec![Term::Application {
+        head: Operator {
+            arity: 0,
+            id: 1,
+            name: None,
         },
-    ];
+        args: vec![],
+    }];
 
     assert!(Rule::is_valid(&lhs, &rhs));
 }
@@ -121,16 +119,14 @@ fn rule_is_valid_yes() {
 fn rule_is_valid_lhs_var() {
     let lhs = Term::Variable(Variable { name: None, id: 0 });
 
-    let rhs = vec![
-        Term::Application {
-            head: Operator {
-                arity: 0,
-                id: 1,
-                name: None,
-            },
-            args: vec![],
+    let rhs = vec![Term::Application {
+        head: Operator {
+            arity: 0,
+            id: 1,
+            name: None,
         },
-    ];
+        args: vec![],
+    }];
 
     assert!(!Rule::is_valid(&lhs, &rhs));
 }
@@ -160,16 +156,14 @@ fn rule_new_some() {
         args: vec![],
     };
 
-    let rhs = vec![
-        Term::Application {
-            head: Operator {
-                arity: 0,
-                id: 1,
-                name: None,
-            },
-            args: vec![],
+    let rhs = vec![Term::Application {
+        head: Operator {
+            arity: 0,
+            id: 1,
+            name: None,
         },
-    ];
+        args: vec![],
+    }];
 
     let rule = Rule {
         lhs: lhs.clone(),
@@ -267,21 +261,19 @@ fn signature_parse() {
             Term::Variable(z.clone()),
         ],
     };
-    let s_rhs = vec![
-        Term::Application {
-            head: a.clone(),
-            args: vec![
-                Term::Application {
-                    head: a.clone(),
-                    args: vec![Term::Variable(x.clone()), Term::Variable(z.clone())],
-                },
-                Term::Application {
-                    head: a.clone(),
-                    args: vec![Term::Variable(y.clone()), Term::Variable(z.clone())],
-                },
-            ],
-        },
-    ];
+    let s_rhs = vec![Term::Application {
+        head: a.clone(),
+        args: vec![
+            Term::Application {
+                head: a.clone(),
+                args: vec![Term::Variable(x.clone()), Term::Variable(z.clone())],
+            },
+            Term::Application {
+                head: a.clone(),
+                args: vec![Term::Variable(y.clone()), Term::Variable(z.clone())],
+            },
+        ],
+    }];
     let s_rule = Rule::new(s_lhs, s_rhs).expect("new S rule");
 
     let k_lhs = Term::Application {
@@ -397,4 +389,22 @@ fn unify_test() {
         },
     );
     assert_eq!(Some(hm2), Term::unify(vec![(t3.clone(), t4.clone())]));
+}
+
+#[test]
+fn rewrite_test() {
+    let mut sig = Signature::default();
+
+    // build a term
+    let s_str = "S x_ y_ z_ = x_ z_ (y_ z_);";
+    let k_str = "K x_ y_ = x_;";
+    let l_str = "K S K;";
+    let r_str = "S;";
+
+    let (trs, terms) = sig.parse(&(s_str.to_owned() + k_str + l_str + r_str))
+        .expect("parse");
+    let l_term = &terms[0];
+    let r_term = terms[1].clone();
+
+    assert_eq!(trs.rewrite(&l_term), Some(vec![r_term]));
 }

--- a/src/types/tests.rs
+++ b/src/types/tests.rs
@@ -3,6 +3,48 @@ use std::hash::Hash;
 use super::*;
 
 #[test]
+fn term_substitute_test() {
+    let mut sig = Signature::default();
+    let y = sig.get_var("y");
+    let z = sig.get_var("z");
+
+    // build a term
+    let s_before = "S K y_ z_;";
+    let (_, terms) = sig.parse(s_before).expect("parse of S x_ y_ z_");
+    let term_before = terms[0].clone();
+
+    // build a substitution
+    let s = sig.get_op("S", 0);
+    let s_term = Term::Application {
+        head: s,
+        args: vec![],
+    };
+    let k = sig.get_op("K", 0);
+    let k_term = Term::Application {
+        head: k,
+        args: vec![],
+    };
+    let mut sub = HashMap::new();
+    sub.insert(y, s_term);
+    sub.insert(z, k_term);
+
+    // build the term after substitution
+    let s_after = "S K S K;";
+    let (_, terms) = sig.parse(s_after).expect("parse of 'S K S K'");
+    let term_after = terms[0].clone();
+
+    // check for equality
+    assert_eq!(term_before.substitute(&sub), term_after);
+    assert_ne!(term_before, term_before.substitute(&sub));
+    assert_ne!(term_before, term_after);
+    assert_eq!(term_before.substitute(&HashMap::new()), term_before);
+    assert_ne!(
+        term_before.substitute(&HashMap::new()),
+        term_before.substitute(&sub)
+    );
+}
+
+#[test]
 fn variable_name() {
     let v1 = Variable { id: 7, name: None };
     let v2 = Variable {

--- a/src/types/tests.rs
+++ b/src/types/tests.rs
@@ -46,7 +46,7 @@ fn variable_show() {
         name: Some("blah".to_string()),
     };
 
-    assert_eq!(v1.show(), "".to_string());
+    assert_eq!(v1.show(), "<var 7>".to_string());
     assert_ne!(v1.show(), "blah".to_string());
     assert_ne!(v2.show(), "".to_string());
     assert_eq!(v2.show(), "blah".to_string());
@@ -98,14 +98,16 @@ fn rule_is_valid_yes() {
         args: vec![],
     };
 
-    let rhs: Vec<Term<Var, Op>> = vec![Term::Application {
-        head: Op {
-            arity: 0,
-            id: 1,
-            name: None,
+    let rhs: Vec<Term<Var, Op>> = vec![
+        Term::Application {
+            head: Op {
+                arity: 0,
+                id: 1,
+                name: None,
+            },
+            args: vec![],
         },
-        args: vec![],
-    }];
+    ];
 
     assert!(Rule::is_valid(&lhs, &rhs));
 }
@@ -113,14 +115,16 @@ fn rule_is_valid_yes() {
 fn rule_is_valid_lhs_var() {
     let lhs = Term::Variable(Var { name: None, id: 0 });
 
-    let rhs = vec![Term::Application {
-        head: Op {
-            arity: 0,
-            id: 1,
-            name: None,
+    let rhs = vec![
+        Term::Application {
+            head: Op {
+                arity: 0,
+                id: 1,
+                name: None,
+            },
+            args: vec![],
         },
-        args: vec![],
-    }];
+    ];
 
     assert!(!Rule::is_valid(&lhs, &rhs));
 }
@@ -150,14 +154,16 @@ fn rule_new_some() {
         args: vec![],
     };
 
-    let rhs = vec![Term::Application {
-        head: Op {
-            arity: 0,
-            id: 1,
-            name: None,
+    let rhs = vec![
+        Term::Application {
+            head: Op {
+                arity: 0,
+                id: 1,
+                name: None,
+            },
+            args: vec![],
         },
-        args: vec![],
-    }];
+    ];
 
     let rule = Rule {
         lhs: lhs.clone(),
@@ -246,19 +252,21 @@ fn signature_parse() {
             Term::Variable(z.clone()),
         ],
     };
-    let s_rhs = vec![Term::Application {
-        head: a.clone(),
-        args: vec![
-            Term::Application {
-                head: a.clone(),
-                args: vec![Term::Variable(x.clone()), Term::Variable(z.clone())],
-            },
-            Term::Application {
-                head: a.clone(),
-                args: vec![Term::Variable(y.clone()), Term::Variable(z.clone())],
-            },
-        ],
-    }];
+    let s_rhs = vec![
+        Term::Application {
+            head: a.clone(),
+            args: vec![
+                Term::Application {
+                    head: a.clone(),
+                    args: vec![Term::Variable(x.clone()), Term::Variable(z.clone())],
+                },
+                Term::Application {
+                    head: a.clone(),
+                    args: vec![Term::Variable(y.clone()), Term::Variable(z.clone())],
+                },
+            ],
+        },
+    ];
     let s_rule = Rule::new(s_lhs, s_rhs).expect("new S rule");
 
     let k_lhs = Term::Application {


### PR DESCRIPTION
- Removes `Arity_` and `Name_` aliases along with their corresponding traits
  `Arity` and `Name`. The more idiomatic way is to just use the underlying
  types, `usize` and `Option<String>`.
- Consolidates the `Symbol` trait to each `Variable` and `Operator` with some
  changes:

  ```rust
  pub trait Variable: Eq + Ord + Hash + Clone {
      /// Construct a new `Variable` that is larger than the given Variable`.
      fn next(Option<&Self>) -> Self;
  
       /// A human-readable representation of `self`.
      fn show(&self) -> String { "<variable>".to_string() }
  }
  pub trait Operator: Eq + Hash + Clone {
      fn arity(&self) -> usize;
  
       /// A human-readable representation of `self`.
      fn show(&self) -> String { "<operator>".to_string() }
  }
  ```