### PR TITLE
refactor type aliases and traits

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -507,12 +507,10 @@ mod tests {
             head: a,
             args: vec![],
         };
-        let rhs = vec![
-            Term::Application {
-                head: b,
-                args: vec![],
-            },
-        ];
+        let rhs = vec![Term::Application {
+            head: b,
+            args: vec![],
+        }];
         let rule = Statement::Rule(Rule::new(lhs, rhs).unwrap());
 
         assert_eq!(parsed_rule, Ok((CompleteStr(""), rule)));

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -91,7 +91,10 @@ impl Parser {
         if name == "" {
             None
         } else {
-            self.variables.iter().find(|&v| v.show() == name).cloned()
+            self.variables
+                .iter()
+                .find(|&v| v.name() == Some(name))
+                .cloned()
         }
     }
     /// Returns a [`Variable`] `v` where `v` has the lowest `id` of any [`Variable`] in
@@ -102,7 +105,7 @@ impl Parser {
         match self.has_var(name) {
             Some(v) => v,
             None => {
-                let v = Var::next(self.variables.iter().max()).named(name.to_string());
+                let v = Var::new_distinct(&self.variables, Some(name.to_string()));
                 self.variables.push(v.clone());
                 v
             }
@@ -118,7 +121,7 @@ impl Parser {
     pub fn has_op(&mut self, name: &str, arity: usize) -> Option<Op> {
         self.operators
             .iter()
-            .find(|&o| o.show() == name && o.arity() == arity)
+            .find(|&o| o.name() == Some(name) && o.arity() == arity)
             .cloned()
     }
     /// Returns an [`Operator`] `v` where `v` has the lowest `id` of any [`Operator`] in

--- a/src/types/tests.rs
+++ b/src/types/tests.rs
@@ -98,16 +98,14 @@ fn rule_is_valid_yes() {
         args: vec![],
     };
 
-    let rhs: Vec<Term<Var, Op>> = vec![
-        Term::Application {
-            head: Op {
-                arity: 0,
-                id: 1,
-                name: None,
-            },
-            args: vec![],
+    let rhs: Vec<Term<Var, Op>> = vec![Term::Application {
+        head: Op {
+            arity: 0,
+            id: 1,
+            name: None,
         },
-    ];
+        args: vec![],
+    }];
 
     assert!(Rule::is_valid(&lhs, &rhs));
 }
@@ -115,16 +113,14 @@ fn rule_is_valid_yes() {
 fn rule_is_valid_lhs_var() {
     let lhs = Term::Variable(Var { name: None, id: 0 });
 
-    let rhs = vec![
-        Term::Application {
-            head: Op {
-                arity: 0,
-                id: 1,
-                name: None,
-            },
-            args: vec![],
+    let rhs = vec![Term::Application {
+        head: Op {
+            arity: 0,
+            id: 1,
+            name: None,
         },
-    ];
+        args: vec![],
+    }];
 
     assert!(!Rule::is_valid(&lhs, &rhs));
 }
@@ -154,16 +150,14 @@ fn rule_new_some() {
         args: vec![],
     };
 
-    let rhs = vec![
-        Term::Application {
-            head: Op {
-                arity: 0,
-                id: 1,
-                name: None,
-            },
-            args: vec![],
+    let rhs = vec![Term::Application {
+        head: Op {
+            arity: 0,
+            id: 1,
+            name: None,
         },
-    ];
+        args: vec![],
+    }];
 
     let rule = Rule {
         lhs: lhs.clone(),
@@ -252,21 +246,19 @@ fn signature_parse() {
             Term::Variable(z.clone()),
         ],
     };
-    let s_rhs = vec![
-        Term::Application {
-            head: a.clone(),
-            args: vec![
-                Term::Application {
-                    head: a.clone(),
-                    args: vec![Term::Variable(x.clone()), Term::Variable(z.clone())],
-                },
-                Term::Application {
-                    head: a.clone(),
-                    args: vec![Term::Variable(y.clone()), Term::Variable(z.clone())],
-                },
-            ],
-        },
-    ];
+    let s_rhs = vec![Term::Application {
+        head: a.clone(),
+        args: vec![
+            Term::Application {
+                head: a.clone(),
+                args: vec![Term::Variable(x.clone()), Term::Variable(z.clone())],
+            },
+            Term::Application {
+                head: a.clone(),
+                args: vec![Term::Variable(y.clone()), Term::Variable(z.clone())],
+            },
+        ],
+    }];
     let s_rule = Rule::new(s_lhs, s_rhs).expect("new S rule");
 
     let k_lhs = Term::Application {

--- a/src/types/tests.rs
+++ b/src/types/tests.rs
@@ -47,9 +47,9 @@ fn variable_show() {
     };
 
     assert_eq!(v1.show(), "<var 7>".to_string());
-    assert_ne!(v1.show(), "blah".to_string());
-    assert_ne!(v2.show(), "".to_string());
+    assert_eq!(v1.name(), None);
     assert_eq!(v2.show(), "blah".to_string());
+    assert_eq!(v2.name(), Some("blah"));
 }
 #[test]
 fn variable_eq() {

--- a/src/types/tests.rs
+++ b/src/types/tests.rs
@@ -46,7 +46,7 @@ fn variable_show() {
         name: Some("blah".to_string()),
     };
 
-    assert_eq!(v1.show(), "".to_string());
+    assert_eq!(v1.show(), "<var 7>".to_string());
     assert_ne!(v1.show(), "blah".to_string());
     assert_ne!(v2.show(), "".to_string());
     assert_eq!(v2.show(), "blah".to_string());
@@ -98,14 +98,16 @@ fn rule_is_valid_yes() {
         args: vec![],
     };
 
-    let rhs: Vec<Term<Var, Op>> = vec![Term::Application {
-        head: Op {
-            arity: 0,
-            id: 1,
-            name: None,
+    let rhs: Vec<Term<Var, Op>> = vec![
+        Term::Application {
+            head: Op {
+                arity: 0,
+                id: 1,
+                name: None,
+            },
+            args: vec![],
         },
-        args: vec![],
-    }];
+    ];
 
     assert!(Rule::is_valid(&lhs, &rhs));
 }
@@ -113,14 +115,16 @@ fn rule_is_valid_yes() {
 fn rule_is_valid_lhs_var() {
     let lhs = Term::Variable(Var { name: None, id: 0 });
 
-    let rhs = vec![Term::Application {
-        head: Op {
-            arity: 0,
-            id: 1,
-            name: None,
+    let rhs = vec![
+        Term::Application {
+            head: Op {
+                arity: 0,
+                id: 1,
+                name: None,
+            },
+            args: vec![],
         },
-        args: vec![],
-    }];
+    ];
 
     assert!(!Rule::is_valid(&lhs, &rhs));
 }
@@ -150,14 +154,16 @@ fn rule_new_some() {
         args: vec![],
     };
 
-    let rhs = vec![Term::Application {
-        head: Op {
-            arity: 0,
-            id: 1,
-            name: None,
+    let rhs = vec![
+        Term::Application {
+            head: Op {
+                arity: 0,
+                id: 1,
+                name: None,
+            },
+            args: vec![],
         },
-        args: vec![],
-    }];
+    ];
 
     let rule = Rule {
         lhs: lhs.clone(),
@@ -246,19 +252,21 @@ fn signature_parse() {
             Term::Variable(z.clone()),
         ],
     };
-    let s_rhs = vec![Term::Application {
-        head: a.clone(),
-        args: vec![
-            Term::Application {
-                head: a.clone(),
-                args: vec![Term::Variable(x.clone()), Term::Variable(z.clone())],
-            },
-            Term::Application {
-                head: a.clone(),
-                args: vec![Term::Variable(y.clone()), Term::Variable(z.clone())],
-            },
-        ],
-    }];
+    let s_rhs = vec![
+        Term::Application {
+            head: a.clone(),
+            args: vec![
+                Term::Application {
+                    head: a.clone(),
+                    args: vec![Term::Variable(x.clone()), Term::Variable(z.clone())],
+                },
+                Term::Application {
+                    head: a.clone(),
+                    args: vec![Term::Variable(y.clone()), Term::Variable(z.clone())],
+                },
+            ],
+        },
+    ];
     let s_rule = Rule::new(s_lhs, s_rhs).expect("new S rule");
 
     let k_lhs = Term::Application {


### PR DESCRIPTION
- Removes `Arity_` and `Name_` aliases along with their corresponding traits
  `Arity` and `Name`. The more idiomatic way is to just use the underlying
  types, `usize` and `Option<String>`.
- Consolidates the `Symbol` trait to each `Variable` and `Operator` with some
  changes:

  ```rust
  pub trait Variable: Eq + Ord + Hash + Clone {
      /// Construct a new `Variable` that is larger than the given `Variable`.
      fn next(Option<&Self>) -> Self;

      /// A human-readable representation of `self`.
      fn show(&self) -> String { "<variable>".to_string() }
  }
  pub trait Operator: Eq + Hash + Clone {
      fn arity(&self) -> usize;

      /// A human-readable representation of `self`.
      fn show(&self) -> String { "<operator>".to_string() }
  }
  ```