### PR TITLE
reintroduce Signature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,45 +8,48 @@
 //!
 //! # fn main() {
 //! // We can parse a string representation of SK combinatory logic,
+//! let mut sig = Signature::default();
 //! let sk_rules = "S x_ y_ z_ = (x_ z_) (y_ z_); K x_ y_ = x_;";
-//! let parsed_trs = parse_trs(&vec![], sk_rules).expect("parsed TRS");
+//! let trs = parse_trs(&mut sig, sk_rules).expect("parsed TRS");
 //!
 //! // and we can also parse an arbitrary term.
+//! let mut sig = Signature::default();
 //! let term = "S K K (K S K)";
-//! let parsed_term = parse_term(&vec![], term).expect("parsed term");
+//! let parsed_term = parse_term(&mut sig, term).expect("parsed term");
 //!
-//! // These can also be constructed by hand. Let's look at the term:
-//! let app = Op::new(0, 2, Some(".".to_string()));
-//! let s = Op::new(1, 0, Some("S".to_string()));
-//! let k = Op::new(2, 0, Some("K".to_string()));
+//! // These can also be constructed by hand.
+//! let mut sig = Signature::default();
+//! let app = sig.new_op(2, Some(".".to_string()));
+//! let s = sig.new_op(0, Some("S".to_string()));
+//! let k = sig.new_op(0, Some("K".to_string()));
 //!
 //! let constructed_term = Term::Application {
-//!     head: app.clone(),
+//!     op: app,
 //!     args: vec![
 //!         Term::Application {
-//!             head: app.clone(),
+//!             op: app,
 //!             args: vec![
 //!                 Term::Application {
-//!                     head: app.clone(),
+//!                     op: app,
 //!                     args: vec![
-//!                         Term::Application { head: s.clone(), args: vec![] },
-//!                         Term::Application { head: k.clone(), args: vec![] },
+//!                         Term::Application { op: s, args: vec![] },
+//!                         Term::Application { op: k, args: vec![] },
 //!                     ]
 //!                 },
-//!                 Term::Application { head: k.clone(), args: vec![] }
+//!                 Term::Application { op: k, args: vec![] }
 //!             ]
 //!         },
 //!         Term::Application {
-//!             head: app.clone(),
+//!             op: app,
 //!             args: vec![
 //!                 Term::Application {
-//!                     head: app.clone(),
+//!                     op: app,
 //!                     args: vec![
-//!                         Term::Application { head: k.clone(), args: vec![] },
-//!                         Term::Application { head: s.clone(), args: vec![] },
+//!                         Term::Application { op: k, args: vec![] },
+//!                         Term::Application { op: s, args: vec![] },
 //!                     ]
 //!                 },
-//!                 Term::Application { head: k.clone(), args: vec![] }
+//!                 Term::Application { op: k, args: vec![] }
 //!             ]
 //!         }
 //!     ]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -17,8 +17,17 @@ pub enum ParseError {
     ParseFailed,
 }
 
-pub fn parse_trs(input: &str, operators: &[Op]) -> Result<TRS<Var, Op>, ParseError> {
-    let (_parser, result) = Parser::new(operators).trs(CompleteStr(input));
+pub fn parse_trs(sig: &mut Signature, input: &str) -> Result<TRS, ParseError> {
+    let (_parser, result) = Parser::new(sig).trs(CompleteStr(input));
+    match result {
+        Ok((CompleteStr(""), trs)) => Ok(trs),
+        Ok((CompleteStr(_), _)) => Err(ParseError::ParseIncomplete),
+        Err(_) => Err(ParseError::ParseFailed),
+    }
+}
+
+pub fn parse_term(sig: &mut Signature, input: &str) -> Result<Term, ParseError> {
+    let (_parser, result) = Parser::new(sig).top_term(CompleteStr(input));
     match result {
         Ok((CompleteStr(""), t)) => Ok(t),
         Ok((CompleteStr(_), _)) => Err(ParseError::ParseIncomplete),
@@ -26,186 +35,156 @@ pub fn parse_trs(input: &str, operators: &[Op]) -> Result<TRS<Var, Op>, ParseErr
     }
 }
 
-pub fn parse_term(input: &str, operators: &[Op]) -> Result<Term<Var, Op>, ParseError> {
-    let (_parser, result) = Parser::new(operators).top_term(CompleteStr(input));
+pub fn parse(sig: &mut Signature, input: &str) -> Result<(TRS, Vec<Term>), ParseError> {
+    let (_parser, result) = Parser::new(sig).program(CompleteStr(input));
     match result {
-        Ok((CompleteStr(""), t)) => Ok(t),
-        Ok((CompleteStr(_), _)) => Err(ParseError::ParseIncomplete),
-        Err(_) => Err(ParseError::ParseFailed),
-    }
-}
-
-pub fn parse(
-    input: &str,
-    operators: &[Op],
-) -> Result<(TRS<Var, Op>, Vec<Term<Var, Op>>), ParseError> {
-    let (_parser, result) = Parser::new(operators).program(CompleteStr(input));
-    match result {
-        Ok((CompleteStr(""), o)) => {
-            let (srs, sts): (Vec<Statement>, Vec<Statement>) =
-                o.into_iter().partition(|x| match *x {
-                    Statement::Rule(_) => true,
-                    _ => false,
-                });
-
-            let rs = srs.into_iter()
-                .filter_map(|x| match x {
-                    Statement::Rule(r) => Some(r),
-                    _ => None,
-                })
-                .collect();
-
-            let ts = sts.into_iter()
-                .filter_map(|x| match x {
-                    Statement::Term(t) => Some(t),
-                    _ => None,
-                })
-                .collect();
-
-            Ok((TRS::new(rs), ts))
+        Ok((CompleteStr(""), stmts)) => {
+            let mut terms = Vec::new();
+            let mut rules = Vec::new();
+            for stmt in stmts {
+                match stmt {
+                    Statement::Term(t) => terms.push(t),
+                    Statement::Rule(r) => rules.push(r),
+                }
+            }
+            Ok((TRS::new(rules), terms))
         }
-        Ok((CompleteStr(_), _)) => Err(ParseError::ParseIncomplete),
+        Ok((CompleteStr(r), e)) => {
+            println!("r: {} AND e: {:?}", r, e);
+            Err(ParseError::ParseIncomplete)
+        }
         Err(_) => Err(ParseError::ParseFailed),
     }
 }
 
 #[derive(Debug, PartialEq)]
 pub enum Statement {
-    Term(Term<Var, Op>),
-    Rule(Rule<Var, Op>),
+    Term(Term),
+    Rule(Rule),
 }
 
 #[derive(Debug)]
-pub struct Parser {
-    operators: Vec<Op>,
-    variables: Vec<Var>,
+pub struct Parser<'a> {
+    sig: &'a mut Signature,
+    dv: usize,
 }
-impl Parser {
-    /// Returns [`Some(v)`] where `v` has the lowest `id` of any [`Variable`] in
-    /// `self` named `name` if such a [`Variable`] exists, otherwise [`None`].
+impl<'a> Parser<'a> {
+    /// Returns `Some(v)` where `v` has the lowest `id` of any [`Variable`] in
+    /// `self` named `name` if such a [`Variable`] exists, otherwise `None`.
     ///
-    /// [`Some(v)`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some
-    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
     /// [`Variable`]: trait.Variable.html
-    pub fn has_var(&self, name: &str) -> Option<Var> {
+    pub fn has_var(&self, name: &str) -> Option<Variable> {
         if name == "" {
             None
         } else {
-            self.variables
+            self.sig
+                .variables
                 .iter()
-                .find(|&v| v.name() == Some(name))
-                .cloned()
+                .enumerate()
+                .skip(self.dv)
+                .find(|&(_, ref var_name)| var_name.as_ref().map(|s| s.as_str()) == Some(name))
+                .map(|(id, _)| Variable { id })
         }
     }
     /// Returns a [`Variable`] `v` where `v` has the lowest `id` of any [`Variable`] in
     /// `self` named `name`, creating this [`Variable`] if necessary.
     ///
     /// [`Variable`]: trait.Variable.html
-    pub fn get_var(&mut self, name: &str) -> Var {
+    pub fn get_var(&mut self, name: &str) -> Variable {
         match self.has_var(name) {
-            Some(v) => v,
-            None => {
-                let v = Var::new_distinct(&self.variables, Some(name.to_string()));
-                self.variables.push(v.clone());
-                v
-            }
+            Some(var) => var,
+            None => self.sig.new_var(Some(name.to_string())),
         }
     }
-    /// Returns [`Some(o)`] where `o` has the lowest `id` of any [`Operator`] in
+    /// Returns `Some(o)` where `o` has the lowest `id` of any [`Operator`] in
     /// `self` named `name` with arity `arity` if such an [`Operator`] exists,
-    /// otherwise [`None`].
+    /// otherwise `None`.
     ///
-    /// [`Some(v)`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some
-    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
-    /// [`Operator`]: trait.Operator.html
-    pub fn has_op(&mut self, name: &str, arity: usize) -> Option<Op> {
-        self.operators
+    /// [`Operator`]: struct.Operator.html
+    pub fn has_op(&self, name: &str, arity: u32) -> Option<Operator> {
+        self.sig
+            .operators
             .iter()
-            .find(|&o| o.name() == Some(name) && o.arity() == arity)
-            .cloned()
+            .enumerate()
+            .find(|&(_, &(op_arity, ref op_name))| {
+                op_arity == arity && op_name.as_ref().map(|s| s.as_str()) == Some(name)
+            })
+            .map(|(id, _)| Operator { id })
     }
-    /// Returns an [`Operator`] `v` where `v` has the lowest `id` of any [`Operator`] in
-    /// `self` named `name` with arity `arity`, creating this [`Operator`] if necessary.
+    /// Returns an [`Operator`] with the given `name` with arity `arity`,
+    /// creating it if necessary.
     ///
-    /// [`Operator`]: trait.Operator.html
-    pub fn get_op(&mut self, name: &str, arity: usize) -> Op {
+    /// [`Operator`]: struct.Operator.html
+    pub fn get_op(&mut self, name: &str, arity: u32) -> Operator {
         match self.has_op(name, arity) {
-            Some(o) => o,
-            None => {
-                let o = Op::new_distinct(&self.operators, arity, Some(name.to_string()));
-                self.operators.push(o.clone());
-                o
-            }
+            Some(op) => op,
+            None => self.sig.new_op(arity, Some(name.to_string())),
         }
     }
-    /// `self` forgets every currently tracked [`Variable`].
-    ///
-    /// [`Variable`]: trait.Variable.html
+    /// Forgets every currently tracked `Variable`.
     pub fn clear_variables(&mut self) {
-        self.variables.clear();
+        self.dv = self.sig.variables.len();
     }
-    pub fn new(operators: &[Op]) -> Parser {
-        Parser {
-            operators: operators.to_vec(),
-            variables: vec![],
-        }
+    pub fn new(sig: &'a mut Signature) -> Parser<'a> {
+        let dv = sig.variables.len();
+        Parser { sig, dv }
     }
     pub fn get_op_wrapped<'b>(
-        mut self: Parser,
+        mut self,
         input: CompleteStr<'b>,
         name: &str,
-        arity: usize,
-    ) -> (Self, IResult<CompleteStr<'b>, Op>) {
+        arity: u32,
+    ) -> (Self, IResult<CompleteStr<'b>, Operator>) {
         let op = self.get_op(name, arity);
         (self, Ok((input, op)))
     }
 
-    method!(variable<Parser, CompleteStr, Term<Var, Op>>, mut self,
+    method!(variable<Parser<'a>, CompleteStr, Term>, mut self,
             map!(terminated!(identifier, underscore),
                  |v| Term::Variable(self.get_var(v.0)))
     );
 
-    method!(application<Parser, CompleteStr, Term<Var, Op>>, mut self,
+    method!(application<Parser<'a>, CompleteStr, Term>, mut self,
             alt!(call_m!(self.standard_application) |
                  call_m!(self.constant) |
                  call_m!(self.binary_application))
     );
 
     // there was a bug in delimited! (or in tuple_parser! closures)
-    method!(standard_application<Parser, CompleteStr, Term<Var, Op>>, mut self,
+    method!(standard_application<Parser<'a>, CompleteStr, Term>, mut self,
             do_parse!(name: identifier >>
                       lparen >>
                       args: many0!(ws!(call_m!(self.term))) >>
                       rparen >>
-                      head: call_m!(self.get_op_wrapped,
+                      op: call_m!(self.get_op_wrapped,
                                     name.0,
-                                    args.len()) >>
-                      (Term::Application{head, args}))
+                                    args.len() as u32) >>
+                      (Term::Application{op, args}))
     );
 
-    method!(constant<Parser, CompleteStr, Term<Var, Op>>, mut self,
+    method!(constant<Parser<'a>, CompleteStr, Term>, mut self,
             do_parse!(name: identifier >>
-                      head: call_m!(self.get_op_wrapped,
+                      op: call_m!(self.get_op_wrapped,
                                     name.0,
                                     0) >>
-                      (Term::Application{head, args: vec![]}))
+                      (Term::Application{op, args: vec![]}))
     );
 
-    method!(binary_application<Parser, CompleteStr, Term<Var, Op>>, mut self,
+    method!(binary_application<Parser<'a>, CompleteStr, Term>, mut self,
             do_parse!(lparen >>
                       t1: ws!(call_m!(self.term)) >>
                       t2: ws!(call_m!(self.term)) >>
-                      head: call_m!(self.get_op_wrapped, ".", 2) >>
+                      op: call_m!(self.get_op_wrapped, ".", 2) >>
                       rparen >>
-                      (Term::Application{ head, args: vec![t1, t2] }))
+                      (Term::Application{ op, args: vec![t1, t2] }))
     );
 
-    method!(term<Parser, CompleteStr, Term<Var, Op>>, mut self,
+    method!(term<Parser<'a>, CompleteStr, Term>, mut self,
             alt!(call_m!(self.variable) | call_m!(self.application))
     );
 
-    method!(top_term<Parser, CompleteStr, Term<Var, Op>>, mut self,
-            map!(do_parse!(head: call_m!(self.get_op_wrapped, ".", 2) >>
+    method!(top_term<Parser<'a>, CompleteStr, Term>, mut self,
+            map!(do_parse!(op: call_m!(self.get_op_wrapped, ".", 2) >>
                            args: separated_nonempty_list!(
                                multispace,
                                alt!(call_m!(self.term) |
@@ -213,17 +192,18 @@ impl Parser {
                                               term: call_m!(self.top_term) >>
                                               rparen >>
                                               (term)))) >>
-                           (head, args)),
-                 |(h, a)| { let mut it = a.into_iter();
-                            let init = it.next().unwrap();
-                            it.fold(init, |acc, x|
-                                    Term::Application{
-                                        head: h.clone(),
-                                        args: vec![acc, x],
-                                    })})
+                           (op, args)),
+                 |(op, a)| {
+                     let mut it = a.into_iter();
+                     let init = it.next().unwrap();
+                     it.fold(init, |acc, x| {
+                        let args = vec![acc, x];
+                         Term::Application{ op, args }
+                     })
+                 })
     );
 
-    method!(rule<Parser, CompleteStr, Rule<Var, Op>>, mut self,
+    method!(rule<Parser<'a>, CompleteStr, Rule>, mut self,
             map_opt!(
                 do_parse!(lhs: call_m!(self.top_term) >>
                           ws!(rule_kw) >>
@@ -234,56 +214,46 @@ impl Parser {
                 |(lhs, rhs)| Rule::new(lhs, rhs))
     );
 
-    method!(rule_statement<Parser, CompleteStr, Statement>, mut self,
+    method!(rule_statement<Parser<'a>, CompleteStr, Statement>, mut self,
             map!(call_m!(self.rule),
                  Statement::Rule)
     );
 
-    method!(term_statement<Parser, CompleteStr, Statement>, mut self,
+    method!(term_statement<Parser<'a>, CompleteStr, Statement>, mut self,
             do_parse!(term: call_m!(self.top_term) >>
-                      (Statement::Term(term))));
+                      (Statement::Term(term)))
+    );
 
     method!(
-        comment<Parser, CompleteStr, CompleteStr>,
+        comment<Parser<'a>, CompleteStr, CompleteStr>,
         self,
         preceded!(tag!("#"), take_until_and_consume!("\n"))
     );
 
-    method!(trs<Parser, CompleteStr, TRS<Var, Op>>, mut self,
+    method!(trs<Parser<'a>, CompleteStr, TRS>, mut self,
             add_return_error!(
                 ErrorKind::Custom(1),
                 do_parse!(
                     rules: many0!(
-                        map!(
-                            do_parse!(
-                                many0!(ws!(call_m!(self.comment))) >>
-                                rule: call_m!(self.rule) >>
-                                ws!(semicolon) >>
-                                many0!(ws!(call_m!(self.comment))) >>
-                                (rule)),
-                            |r| {self.clear_variables(); r})) >>
+                        do_parse!(
+                            many0!(ws!(call_m!(self.comment))) >>
+                            rule: call_m!(self.rule) >>
+                            ws!(semicolon) >>
+                            many0!(ws!(call_m!(self.comment))) >>
+                            ({ self.clear_variables(); rule }))) >>
                     (TRS::new(rules))))
     );
 
-    method!(program<Parser, CompleteStr, Vec<Statement>>, mut self,
+    method!(program<Parser<'a>, CompleteStr, Vec<Statement>>, mut self,
             add_return_error!(
                 ErrorKind::Custom(1),
-                many0!(map!(do_parse!(many0!(ws!(call_m!(self.comment))) >>
-                                      statement: alt!(call_m!(self.rule_statement) |
-                                                      call_m!(self.term_statement)) >>
-                                      ws!(semicolon) >>
-                                      many0!(ws!(call_m!(self.comment))) >>
-                                      (statement)),
-                            |s| {self.clear_variables(); s})))
+                many0!(do_parse!(many0!(ws!(call_m!(self.comment))) >>
+                                 statement: alt!(call_m!(self.rule_statement) |
+                                                 call_m!(self.term_statement)) >>
+                                 ws!(semicolon) >>
+                                 many0!(ws!(call_m!(self.comment))) >>
+                                 ({ self.clear_variables(); statement }))))
     );
-}
-impl Default for Parser {
-    fn default() -> Self {
-        Parser {
-            operators: vec![],
-            variables: vec![],
-        }
-    }
 }
 
 #[cfg(test)]
@@ -340,7 +310,8 @@ mod tests {
 
     #[test]
     fn var_test() {
-        let mut p = Parser::default();
+        let mut sig = Signature::default();
+        let mut p = Parser::new(&mut sig);
         let abc = p.get_var("abc");
         let (_, var) = p.variable(CompleteStr("abc_"));
         assert_eq!(var, Ok((CompleteStr(""), Term::Variable(abc))));
@@ -348,43 +319,46 @@ mod tests {
 
     #[test]
     fn app_test_1() {
-        let mut p = Parser::default();
+        let mut sig = Signature::default();
+        let mut p = Parser::new(&mut sig);
         let a = p.get_op("a", 0);
         let (_, app) = p.application(CompleteStr("a()"));
         let term = Term::Application {
-            head: a,
+            op: a,
             args: vec![],
         };
         assert_eq!(app, Ok((CompleteStr(""), term)));
     }
     #[test]
     fn app_test_2() {
-        let mut p = Parser::default();
+        let mut sig = Signature::default();
+        let mut p = Parser::new(&mut sig);
         let b = p.get_op("b", 0);
         let (_, app) = p.application(CompleteStr("b"));
         let term = Term::Application {
-            head: b,
+            op: b,
             args: vec![],
         };
         assert_eq!(app, Ok((CompleteStr(""), term)));
     }
     #[test]
     fn app_test_3() {
-        let mut p = Parser::default();
+        let mut sig = Signature::default();
+        let mut p = Parser::new(&mut sig);
         let a = p.get_op(".", 2);
         let b = p.get_op("b", 0);
         let c = p.get_op("c", 0);
         let (_, app) = p.application(CompleteStr("(b c)"));
         let st1 = Term::Application {
-            head: b,
+            op: b,
             args: vec![],
         };
         let st2 = Term::Application {
-            head: c,
+            op: c,
             args: vec![],
         };
         let term = Term::Application {
-            head: a,
+            op: a,
             args: vec![st1, st2],
         };
         assert_eq!(app, Ok((CompleteStr(""), term)));
@@ -392,18 +366,20 @@ mod tests {
 
     #[test]
     fn term_test_1() {
-        let mut p = Parser::default();
+        let mut sig = Signature::default();
+        let mut p = Parser::new(&mut sig);
         let a = p.get_op("a", 0);
         let (_, parsed_term) = p.term(CompleteStr("a()"));
         let term = Term::Application {
-            head: a,
+            op: a,
             args: vec![],
         };
         assert_eq!(parsed_term, Ok((CompleteStr(""), term)));
     }
     #[test]
     fn term_test_2() {
-        let mut p = Parser::default();
+        let mut sig = Signature::default();
+        let mut p = Parser::new(&mut sig);
         let a = p.get_var("a");
         let (_, parsed_term) = p.term(CompleteStr("a_"));
         let term = Term::Variable(a);
@@ -411,7 +387,8 @@ mod tests {
     }
     #[test]
     fn term_test_3() {
-        let mut p = Parser::default();
+        let mut sig = Signature::default();
+        let mut p = Parser::new(&mut sig);
         let a1 = p.get_op("a", 2);
         let x1 = p.get_var("x");
         let y1 = p.get_var("y");
@@ -421,11 +398,11 @@ mod tests {
         let x2 = x1.clone();
         let y1 = Term::Variable(y1);
         let term = Term::Application {
-            head: a1,
+            op: a1,
             args: vec![
                 x1,
                 Term::Application {
-                    head: a2,
+                    op: a2,
                     args: vec![y1, x2],
                 },
             ],
@@ -435,55 +412,57 @@ mod tests {
 
     #[test]
     fn top_term_test() {
-        let (_, parsed_term_vec) = parse("S K K (K S K);", &vec![]).expect("successful parse");
+        let mut sig = Signature::default();
+        let (_, parsed_term_vec) = parse(&mut sig, "S K K (K S K);").expect("successful parse");
 
-        let mut p = Parser::default();
+        let mut sig = Signature::default();
+        let mut p = Parser::new(&mut sig);
         let app = p.get_op(".", 2);
         let s = p.get_op("S", 0);
         let k = p.get_op("K", 0);
         let term = Term::Application {
-            head: app.clone(),
+            op: app.clone(),
             args: vec![
                 Term::Application {
-                    head: app.clone(),
+                    op: app.clone(),
                     args: vec![
                         Term::Application {
-                            head: app.clone(),
+                            op: app.clone(),
                             args: vec![
                                 Term::Application {
-                                    head: s.clone(),
+                                    op: s.clone(),
                                     args: vec![],
                                 },
                                 Term::Application {
-                                    head: k.clone(),
+                                    op: k.clone(),
                                     args: vec![],
                                 },
                             ],
                         },
                         Term::Application {
-                            head: k.clone(),
+                            op: k.clone(),
                             args: vec![],
                         },
                     ],
                 },
                 Term::Application {
-                    head: app.clone(),
+                    op: app.clone(),
                     args: vec![
                         Term::Application {
-                            head: app.clone(),
+                            op: app.clone(),
                             args: vec![
                                 Term::Application {
-                                    head: k.clone(),
+                                    op: k.clone(),
                                     args: vec![],
                                 },
                                 Term::Application {
-                                    head: s.clone(),
+                                    op: s.clone(),
                                     args: vec![],
                                 },
                             ],
                         },
                         Term::Application {
-                            head: k.clone(),
+                            op: k.clone(),
                             args: vec![],
                         },
                     ],
@@ -498,17 +477,18 @@ mod tests {
 
     #[test]
     fn rule_test() {
-        let mut p = Parser::default();
+        let mut sig = Signature::default();
+        let mut p = Parser::new(&mut sig);
         let a = p.get_op("a", 0);
         let b = p.get_op("b", 0);
         let (_, parsed_rule) = p.rule_statement(CompleteStr("a = b()"));
 
         let lhs = Term::Application {
-            head: a,
+            op: a,
             args: vec![],
         };
         let rhs = vec![Term::Application {
-            head: b,
+            op: b,
             args: vec![],
         }];
         let rule = Statement::Rule(Rule::new(lhs, rhs).unwrap());
@@ -518,33 +498,35 @@ mod tests {
 
     #[test]
     fn statement_test_1() {
-        let mut p = Parser::default();
+        let mut sig = Signature::default();
+        let mut p = Parser::new(&mut sig);
         let a = p.get_op("a", 0);
         let (_, parsed_statement) = p.term_statement(CompleteStr("a()"));
         let statement = Statement::Term(Term::Application {
-            head: a,
+            op: a,
             args: vec![],
         });
         assert_eq!(parsed_statement, Ok((CompleteStr(""), statement)));
     }
     #[test]
     fn statement_test_2() {
-        let mut p = Parser::default();
+        let mut sig = Signature::default();
+        let mut p = Parser::new(&mut sig);
         let a = p.get_op("a", 0);
         let b = p.get_op("b", 0);
         let dot = p.get_op(".", 2);
         let (_, parsed_statement) = p.term_statement(CompleteStr("a b"));
 
         let st1 = Term::Application {
-            head: a,
+            op: a,
             args: vec![],
         };
         let st2 = Term::Application {
-            head: b,
+            op: b,
             args: vec![],
         };
         let statement = Statement::Term(Term::Application {
-            head: dot,
+            op: dot,
             args: vec![st1, st2],
         });
 
@@ -553,11 +535,12 @@ mod tests {
 
     #[test]
     fn program_test() {
-        let mut p = Parser::default();
+        let mut sig = Signature::default();
+        let mut p = Parser::new(&mut sig);
         let a = p.get_op("a", 0);
         let (_, parsed_program) = p.program(CompleteStr("a();"));
         let program = Statement::Term(Term::Application {
-            head: a,
+            op: a,
             args: vec![],
         });
 
@@ -566,15 +549,17 @@ mod tests {
 
     #[test]
     fn parser_debug() {
-        let p = Parser::default();
+        let mut sig = Signature::default();
+        let p = Parser::new(&mut sig);
         assert_eq!(
             format!("{:?}", p),
-            "Parser { operators: [], variables: [] }"
+            "Parser { sig: Signature { operators: [], variables: [] }, dv: 0 }"
         );
     }
     #[test]
     fn parser_incomplete() {
-        let res = parse("(a b c", &vec![]);
+        let mut sig = Signature::default();
+        let res = parse(&mut sig, "(a b c");
         assert_eq!(res, Err(ParseError::ParseIncomplete));
     }
 }


### PR DESCRIPTION
There are a lot of changes here. Primarily, I realized that having `Variable` and `Operator` as traits was inappropriate. I recommend looking at the docs to see how things look. I still need to add/change documentation, but wanted to get your eyes on this sooner rather than later.

```rust
let term = "S K K (K S K)";
let (_sig, parsed_term) = parse_term(vec![], term).expect("parsed term");
```

```rust
let symbols = vec![
    (2, Some(".".to_string())),
    (0, Some("S".to_string())),
    (0, Some("K".to_string())),
];
let (sig, operators) = Signature::new(symbols);
let app = operators[0];
let s = operators[1];
let k = operators[2];

let term = Term::Application {
    op: app,
    args: vec![
        Term::Application { op: s, args: vec![] },
        Term::Application { op: k, args: vec![] },
    ]
};
```