### PR TITLE
RuleContext: Adding from trait to convert Rules to RuleContexts

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -2973,6 +2973,13 @@ impl RuleContext {
         Rule::new(lhs, rhs).ok_or(())
     }
 }
+impl From<Rule> for RuleContext {
+    fn from(r: Rule) -> RuleContext {
+        let new_lhs = Context::from(r.lhs);
+        let new_rhs = r.rhs.into_iter().map(Context::from).collect();
+        RuleContext::new(new_lhs, new_rhs).unwrap()
+    }
+}
 
 /// A first-order term rewriting system.
 ///


### PR DESCRIPTION
Added trait to convert Rules into RuleContexts to make modifying existing Rules easier in the Program Induction crate.