### PR TITLE
moved tests

### DIFF
--- a/src/types/rule.rs
+++ b/src/types/rule.rs
@@ -1235,22 +1235,23 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn rule_new_test() {
-        //let mut sig = Signature::default();
-        //
-        //let lhs = parse_term(&mut sig, "A").expect("parse of A");
-        //let rhs = vec![parse_term(&mut sig, "B").expect("parse of B")];
-        //let r = Rule::new(lhs, rhs).unwrap();
-        //
-        //let r2 = parse_rule(&mut sig, "A = B").expect("parse of A = B");
-        //
-        //assert_eq!(r, r2);
-        //
-        //let left = parse_term(&mut sig, "A").expect("parse of A");
-        //let right = vec![parse_term(&mut sig, "B").expect("parse of B")];
-        //let r2 = Rule { lhs: left, rhs: right };
-        //
-        //assert_eq!(r, r2);
+        let mut sig = Signature::default();
+        
+        let lhs = parse_term(&mut sig, "A").expect("parse of A");
+        let rhs = vec![parse_term(&mut sig, "B").expect("parse of B")];
+        let r = Rule::new(lhs, rhs).unwrap();
+        
+        let r2 = parse_rule(&mut sig, "A = B").expect("parse of A = B");
+        
+        assert_eq!(r, r2);
+        
+        let left = parse_term(&mut sig, "A").expect("parse of A");
+        let right = vec![parse_term(&mut sig, "B").expect("parse of B")];
+        let r2 = Rule { lhs: left, rhs: right };
+        
+        assert_eq!(r, r2);
     }
 
     #[test]

--- a/src/types/rule.rs
+++ b/src/types/rule.rs
@@ -985,3 +985,497 @@ impl Rule {
         .unwrap()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::{Signature, Term};
+    use super::super::super::parser::*;
+    use std::collections::HashMap;
+    use super::*;
+
+    #[test]
+    fn rulecontext_new_test() {
+        let mut sig = Signature::default();
+        
+        let left = parse_context(&mut sig, "A(B C [!])").expect("parse of A(B C [!])");
+        let b = parse_context(&mut sig, "B [!]").expect("parse of B [!]");
+        let c = parse_context(&mut sig, "C").expect("parse of C");
+        
+        let r = RuleContext::new(left, vec![b, c]).unwrap();
+        
+        assert_eq!(r.pretty(), "A(B, C, [!]) = B [!] | C");
+        
+        let left = parse_context(&mut sig, "A(B C [!])").expect("parse of A(B C [!])");
+        let b = parse_context(&mut sig, "B [!] x_").expect("parse of B [!] x_");
+        let c = parse_context(&mut sig, "C").expect("parse of C");
+        
+        assert_eq!(RuleContext::new(left, vec![b, c]), None);
+        
+        let left = parse_context(&mut sig, "x_").expect("parse of x_");
+        let b = parse_context(&mut sig, "B [!]").expect("parse of B [!]");
+        
+        assert_eq!(RuleContext::new(left, vec![b]), None);       
+    }
+
+    #[test]
+    fn rulecontext_display_test() {
+        let mut sig = Signature::default();
+        
+        let rule = parse_rulecontext(&mut sig, "A B(x_) CONS(SUCC(SUCC(ZERO)) CONS(SUCC(ZERO) CONS(ZERO NIL))) DECC(DECC(DIGIT(1) 0) 5) = [!] CONS(A CONS(B(x_) CONS(SUCC(SUCC(ZERO)) NIL)))")
+            .expect("parse of A B(x_) CONS(SUCC(SUCC(ZERO)) CONS(SUCC(ZERO) CONS(ZERO NIL))) DECC(DECC(DIGIT(1) 0) 5) = [!] CONS(A CONS(B(x_) CONS( SUCC(SUCC(ZERO)) NIL)))");
+        
+        assert_eq!(rule.display(), ".(.(.(A B(x_)) CONS(SUCC(SUCC(ZERO)) CONS(SUCC(ZERO) CONS(ZERO NIL)))) DECC(DECC(DIGIT(1) 0) 5)) = .([!] CONS(A CONS(B(x_) CONS(SUCC(SUCC(ZERO)) NIL))))");
+    }
+
+    #[test]
+    fn rule_context_pretty_test() {
+        let mut sig = Signature::default();
+        
+        let rule = parse_rulecontext(&mut sig, "A B(x_) CONS(SUCC(SUCC(ZERO)) CONS(SUCC(ZERO) CONS(ZERO NIL))) DECC(DECC(DIGIT(1) 0) 5) = [!] CONS(A CONS(B(x_) CONS(SUCC(SUCC(ZERO)) NIL)))")
+            .expect("parse of A B(x_) CONS(SUCC(SUCC(ZERO)) CONS(SUCC(ZERO) CONS(ZERO NIL))) DECC(DECC(DIGIT(1) 0) 5) = [!] CONS(A CONS(B(x_) CONS( SUCC(SUCC(ZERO)) NIL)))");
+        
+        assert_eq!(rule.pretty(), "A B(x_) [2, 1, 0] 105 = [!] [A, B(x_), 2]");
+    }
+
+    #[test]
+    fn subcontexts_test() {
+        let mut sig = Signature::default();
+        
+        let r =
+            parse_rulecontext(&mut sig, "A(x_ [!]) = C(x_) | D([!])")
+            .expect("parse of A(x_ B[!]) = C(x_) | D([!])");
+        
+        let subcontexts: Vec<String> = r.subcontexts()
+            .iter()
+            .map(|(c, p)| format!("({}, {:?})", c.display(), p))
+            .collect();
+        
+        assert_eq!(
+            subcontexts,
+            vec![
+                "(A(x_ [!]), [0])",
+                "(x_, [0, 0])",
+                "([!], [0, 1])",
+                "(C(x_), [1])",
+                "(x_, [1, 0])",
+                "(D([!]), [2])",
+                "([!], [2, 0])",
+            ]
+        );
+    }
+
+    #[test]
+    fn holes_test() {
+        let mut sig = Signature::default();
+        
+        let r =
+            parse_rulecontext(&mut sig, "A(x_ [!]) = C(x_) | D([!])").expect("parse of A(x_ B[!]) = C(x_) | D([!])");
+        
+        let p: &[usize] = &[0, 1];
+        let p2: &[usize] = &[2, 0];
+        
+        assert_eq!(r.holes(), vec![p, p2]); 
+    }
+
+    #[test]
+    fn rulecontext_variables_test() {
+        let mut sig = Signature::default();
+        
+        let r = parse_rulecontext(&mut sig, "A(x_ [!]) = C(x_)").expect("parse of A(x_ [!]) = C(x_)");
+        let r_variables: Vec<String> = r.variables().iter().map(|v| v.display()).collect();
+        
+        assert_eq!(r_variables, vec!["x_"]);
+        
+        let r = parse_rulecontext(&mut sig, "B(y_ z_) = C [!]").expect("parse of B(y_ z_) = C [!]");
+        let r_variables: Vec<String> = r.variables().iter().map(|v| v.display()).collect();
+        
+        assert_eq!(r_variables, vec!["y_", "z_"]);
+    }
+
+    #[test]
+    fn rulecontext_operators_test() {
+        let mut sig = Signature::default();
+        
+        let r = parse_rulecontext(&mut sig, "A(D E) = C([!])").expect("parse of A(D E) = C([!])");
+        let r_ops: Vec<String> = r.operators().iter().map(|o| o.display()).collect();
+        
+        assert_eq!(r_ops, vec!["D", "E", "A", "C"]);
+        
+        let r = parse_rulecontext(&mut sig, "B(F x_) = C [!]").expect("parse of B(F x_) = C [!]");
+        let r_ops: Vec<String> = r.operators().iter().map(|o| o.display()).collect();
+        
+        assert_eq!(r_ops, vec!["F", "B", "C", "."]);   
+    }
+
+    #[test]
+    fn rulecontext_at_test() {
+        let mut sig = Signature::default();
+        
+        let r = parse_rulecontext(&mut sig, "A(x_ [!]) = B | C(x_ [!])").expect("parse of A(x_ [!]) = B | C(x_ [!])");
+        
+        assert_eq!(r.at(&[0]).unwrap().display(), "A(x_ [!])");
+        assert_eq!(r.at(&[0,1]).unwrap().display(), "[!]");
+        assert_eq!(r.at(&[0,0]).unwrap().display(), "x_");
+        assert_eq!(r.at(&[1]).unwrap().display(), "B");
+        assert_eq!(r.at(&[2]).unwrap().display(), "C(x_ [!])");
+    }
+
+    #[test]
+    fn rulecontext_replace_test() {
+        let mut sig = Signature::default();
+        
+        let r = parse_rulecontext(&mut sig, "A(x_) = B | C(x_) | [!]").expect("parse of A(x_) = B| C(x_) | [!]");
+        let new_context = parse_context(&mut sig, "E [!]").expect("parse of E [!]");
+        let new_r = r.replace(&[1], new_context);
+        
+        assert_ne!(r, new_r.clone().unwrap());
+        assert_eq!(new_r.unwrap().pretty(), "A(x_) = E [!] | C(x_) | [!]");
+   
+    }
+
+    #[test]
+    fn to_rule_test() {
+        let mut sig = Signature::default();
+        
+        let r = parse_rulecontext(&mut sig, "A(x_ [!]) = B | C(x_ [!])").expect("parse of A(x_ [!]) = B | C(x_ [!])");
+        
+        assert!(r.to_rule().is_err());
+        
+        let r = parse_rulecontext(&mut sig, "A(x_) = B | C(x_)").expect("parse of A(x_) = B | C(x_)");
+        let rule = r.to_rule().expect("converting RuleContext to Rule");
+        
+        assert_eq!(rule.pretty(), "A(x_) = B | C(x_)");
+    }
+
+    #[test]
+    fn rule_display_test() {
+        let mut sig = Signature::default();
+        
+        let rule = parse_rule(&mut sig, "A B(x_) CONS(SUCC(SUCC(ZERO)) CONS(SUCC(ZERO) CONS(ZERO NIL))) DECC(DECC(DIGIT(1) 0) 5) = CONS(A CONS(B(x_) CONS( SUCC(SUCC(ZERO)) NIL)))")
+            .expect("parse of A B(x_) CONS(SUCC(SUCC(ZERO)) CONS(SUCC(ZERO) CONS(ZERO NIL))) DECC(DECC(DIGIT(1) 0) 5) = CONS(A CONS(B(x_) CONS( SUCC(SUCC(ZERO)) NIL)))");
+        
+        assert_eq!(rule.display(), ".(.(.(A B(x_)) CONS(SUCC(SUCC(ZERO)) CONS(SUCC(ZERO) CONS(ZERO NIL)))) DECC(DECC(DIGIT(1) 0) 5)) = CONS(A CONS(B(x_) CONS(SUCC(SUCC(ZERO)) NIL)))");
+    }
+
+    #[test]
+    fn rule_pretty_test() {
+        let mut sig = Signature::default();
+        
+        let rule = parse_rule(&mut sig, "A B(x_) CONS(SUCC(SUCC(ZERO)) CONS(SUCC(ZERO) CONS(ZERO NIL))) DECC(DECC(DIGIT(1) 0) 5) = CONS(A CONS(B(x_) CONS( SUCC(SUCC(ZERO)) NIL)))")
+            .expect("parse of A B(x_) CONS(SUCC(SUCC(ZERO)) CONS(SUCC(ZERO) CONS(ZERO NIL))) DECC(DECC(DIGIT(1) 0) 5) = CONS(A CONS(B(x_) CONS( SUCC(SUCC(ZERO)) NIL)))");
+        
+        assert_eq!(rule.pretty(), "A B(x_) [2, 1, 0] 105 = [A, B(x_), 2]");
+    }
+
+    #[test]
+    fn size_test() {
+        let mut sig = Signature::default();
+        
+        let r = parse_rule(&mut sig, "A(x_) = B(x_) | C").expect("parse of A(x_) = B(x_) | C");
+        
+        assert_eq!(r.size(), 5);
+    }
+
+    #[test]
+    fn len_test() {
+        let mut sig = Signature::default();
+        
+        let r = parse_rule(&mut sig, "A(x_) = B(x_) | C").expect("parse of A(x_) = B(x_) | C");
+        
+        assert_eq!(r.size(), 5);
+    }
+
+    #[test]
+    fn is_empty_test() {
+        let mut sig = Signature::default();
+        
+        let r = parse_rule(&mut sig, "A(x_) = B(x_) | C").expect("parse of A(x_) = B(x_) | C");
+        
+        assert!(!r.is_empty());
+        
+        let lhs = parse_term(&mut sig, "A").expect("parse of A");
+        let rhs : Vec<Term> = vec![];
+        let r = Rule::new(lhs, rhs).unwrap();
+        
+        assert!(r.is_empty());
+    }
+
+    #[test]
+    fn rhs_test() {
+        let mut sig = Signature::default();
+        
+        let r = parse_rule(&mut sig, "A = B").expect("parse of A = B");
+        let b = parse_term(&mut sig, "B").expect("parse of B");
+        
+        assert_eq!(r.rhs().unwrap(), b);
+        
+        let r = parse_rule(&mut sig, "A = B | C").expect("parse of A = B | C");
+        
+        assert_eq!(r.rhs(), Option::None);
+    }
+
+    #[test]
+    fn clauses_test() {
+        let mut sig = Signature::default();
+        
+        let r = parse_rule(&mut sig, "A = B").expect("parse of A = B");
+        
+        assert_eq!(r.clauses(), vec![r]);
+        
+        let r = parse_rule(&mut sig, "A = B | C").expect("parse of A = B | C");
+        let r1 = parse_rule(&mut sig, "A = B").expect("parse of A = B");
+        let r2 = parse_rule(&mut sig, "A = C").expect("parse of A = C");
+        
+        assert_eq!(r.clauses(), vec![r1, r2]);
+    }
+
+    #[test]
+    fn is_valid_test() {
+
+    }
+
+    #[test]
+    fn rule_new_test() {
+        //let mut sig = Signature::default();
+        //
+        //let lhs = parse_term(&mut sig, "A").expect("parse of A");
+        //let rhs = vec![parse_term(&mut sig, "B").expect("parse of B")];
+        //let r = Rule::new(lhs, rhs).unwrap();
+        //
+        //let r2 = parse_rule(&mut sig, "A = B").expect("parse of A = B");
+        //
+        //assert_eq!(r, r2);
+        //
+        //let left = parse_term(&mut sig, "A").expect("parse of A");
+        //let right = vec![parse_term(&mut sig, "B").expect("parse of B")];
+        //let r2 = Rule { lhs: left, rhs: right };
+        //
+        //assert_eq!(r, r2);
+    }
+
+    #[test]
+    fn add_test() {
+        let mut sig = Signature::default();
+        
+        let c = parse_term(&mut sig, "C").expect("parse of C");
+        let mut r = parse_rule(&mut sig, "A = B").expect("parse of A = B");
+        
+        assert_eq!(r.display(), "A = B");
+        
+        r.add(c);
+        
+        assert_eq!(r.display(), "A = B | C");
+    }
+
+    #[test]
+    fn merge_test() {
+        let mut sig = Signature::default();
+        
+        let mut r = parse_rule(&mut sig, "A = B").expect("parse A = B");
+        let r2 = parse_rule(&mut sig, "A = C").expect("parse A = C");
+        r.merge(&r2);
+        
+        assert_eq!(r.display(), "A = B | C");
+    }
+
+    #[test]
+    fn discard_test() {
+        let mut sig = Signature::default();
+        
+        let mut r = parse_rule(&mut sig, "A(x_) = B(x_) | C").expect("parse of A(x_) = B(x_) | C");
+        let r2 = parse_rule(&mut sig, "A(y_) = B(y_)").expect("parse of A(y_) = B(y_)");
+        r.discard(&r2);
+        
+        assert_eq!(r.display(), "A(x_) = C");
+    }
+
+    #[test]
+    fn contains_test() {
+        let mut sig = Signature::default();
+        
+        let r = parse_rule(&mut sig, "A(x_) = B(x_) | C").expect("parse of A(x_) = B(x_) | C");
+        let r2 = parse_rule(&mut sig, "A(y_) = B(y_)").expect("parse of A(y_) = B(y_)");
+        
+        assert_eq!(r2.contains(&r), None);
+        
+        let mut sub = HashMap::default();
+        let x = r.variables()[0].clone();
+        let y = r2.variables()[0].clone();
+        sub.insert(y, Term::Variable(x));
+        
+        assert_eq!(r.contains(&r2).unwrap(), sub);
+    }
+
+    #[test]
+    fn rule_variables_test() {
+        let mut sig = Signature::default();
+        
+        let r = parse_rule(&mut sig, "A(x_) = C(x_)").expect("parse of A(x_) = C(x_)");
+        let r_variables: Vec<String> = r.variables().iter().map(|v| v.display()).collect();
+        
+        assert_eq!(r_variables, vec!["x_"]);
+        
+        let r = parse_rule(&mut sig, "B(y_ z_) = C").expect("parse of B(y_ z_) = C");
+        let r_variables: Vec<String> = r.variables().iter().map(|v| v.display()).collect();
+        
+        assert_eq!(r_variables, vec!["y_", "z_"]);
+    }
+
+    #[test]
+    fn rule_operators_test() {
+        let mut sig = Signature::default();
+        
+        let r = parse_rule(&mut sig, "A(D E) = C").expect("parse of A(D E) = C");
+        let r_ops: Vec<String> = r.operators().iter().map(|o| o.display()).collect();
+        
+        assert_eq!(r_ops, vec!["D", "E", "A", "C"]);
+        
+        let r = parse_rule(&mut sig, "B(F x_) = C").expect("parse of B(F x_) = C");
+        let r_ops: Vec<String> = r.operators().iter().map(|o| o.display()).collect();
+        
+        assert_eq!(r_ops, vec!["F", "B", "C"]);
+    }
+
+    #[test]
+    fn subterms_test() {
+        let mut sig = Signature::default();
+        
+        let r =
+            parse_rule(&mut sig, "A(x_ B) = C(x_) | D(B)").expect("parse of A(x_ B) = C(x_) | D(B)");
+        
+        let subterms: Vec<String> = r.subterms()
+            .iter()
+            .map(|(t, p)| format!("{}, {:?}", t.display(), p))
+            .collect();
+        
+        assert_eq!(
+            subterms,
+            vec![
+                "A(x_ B), [0]",
+                "x_, [0, 0]",
+                "B, [0, 1]",
+                "C(x_), [1]",
+                "x_, [1, 0]",
+                "D(B), [2]",
+                "B, [2, 0]",
+            ]
+        );
+    }
+
+    #[test]
+    fn rule_at_test() {
+        let mut sig = Signature::default();
+        
+        let r = parse_rule(&mut sig, "A(x_) = B | C(x_)").expect("parse of A(x_) = B | C(x_)");
+        
+        assert_eq!(r.at(&[0]).unwrap().display(), "A(x_)");
+        assert_eq!(r.at(&[0,0]).unwrap().display(), "x_");
+        assert_eq!(r.at(&[1]).unwrap().display(), "B");
+        assert_eq!(r.at(&[2]).unwrap().display(), "C(x_)");
+    }
+
+    #[test]
+    fn rule_replace_test() {
+        let mut sig = Signature::default();
+        
+        let r = parse_rule(&mut sig, "A(x_) = B | C(x_)").expect("parse of A(x_) = B| C(x_)");
+        let new_term = parse_term(&mut sig, "E").expect("parse of E");
+        let new_rule = r.replace(&[1], new_term);
+        
+        assert_ne!(r, new_rule.clone().unwrap());
+        
+        assert_eq!(new_rule.unwrap().display(), "A(x_) = E | C(x_)");
+    }
+
+    #[test]
+    fn pmatch_test() {
+        let mut sig = Signature::default();
+        
+        let r = parse_rule(&mut sig, "A(x_) = B").expect("parse of A(x_) = B");
+        let r2 = parse_rule(&mut sig, "A(y_) = y_").expect("parse of A(y_) = y_");
+        let r3 = parse_rule(&mut sig, "A(z_) = C").expect("parse of A(z_) = C");
+        let r4 = parse_rule(&mut sig, "D(w_) = B").expect("parse of D(w_) = B");
+        let r5 = parse_rule(&mut sig, "A(t_) = B").expect("parse of A(t_) = B");
+        
+        assert_eq!(Rule::pmatch(r.clone(), r2), None);
+        assert_eq!(Rule::pmatch(r.clone(), r3), None);
+        assert_eq!(Rule::pmatch(r.clone(), r4), None);
+        
+        let mut expected_map = HashMap::default();
+        expected_map.insert(
+            r.clone().variables()[0].clone(),
+            Term::Variable(r5.clone().variables()[0].clone()),
+        );
+        
+        assert_eq!(Rule::pmatch(r, r5), Some(expected_map));
+    }
+
+    #[test]
+    fn unify_test() {
+        let mut sig = Signature::default();
+        
+        let r = parse_rule(&mut sig, "A(x_) = B").expect("parse of A(x_) = B");
+        let r2 = parse_rule(&mut sig, "A(y_) = y_").expect("parse of A(y_) = y_");
+        let r3 = parse_rule(&mut sig, "A(z_) = C").expect("parse of A(z_) = C");
+        let r4 = parse_rule(&mut sig, "D(w_) = B").expect("parse of D(w_) = B");
+        let r5 = parse_rule(&mut sig, "A(t_) = B").expect("parse of A(t_) = B");
+        
+        let b = parse_term(&mut sig, "B").expect("parse of B");
+        let mut expected_map = HashMap::default();
+        expected_map.insert(r.clone().variables()[0].clone(), b.clone());
+        expected_map.insert(r2.clone().variables()[0].clone(), b);
+        
+        assert_eq!(Rule::unify(r.clone(), r2), Some(expected_map));
+        
+        assert_eq!(Rule::unify(r.clone(), r3), None);
+        assert_eq!(Rule::unify(r.clone(), r4), None);
+        
+        let mut expected_map = HashMap::default();
+        expected_map.insert(
+            r.clone().variables()[0].clone(),
+             Term::Variable(r5.clone().variables()[0].clone()),
+        );
+        
+        assert_eq!(Rule::unify(r, r5), Some(expected_map));  
+    }
+
+    #[test]
+    fn alpha_test() {
+        let mut sig = Signature::default();
+        
+        let r = parse_rule(&mut sig, "A(x_) = B").expect("parse of A(x_) = B");
+        let r2 = parse_rule(&mut sig, "A(y_) = y_").expect("parse of A(y_) = y_");
+        let r3 = parse_rule(&mut sig, "A(z_) = C").expect("parse of A(z_) = C");
+        let r4 = parse_rule(&mut sig, "D(w_) = B").expect("parse of D(w_) = B");
+        let r5 = parse_rule(&mut sig, "A(t_) = B").expect("parse of A(t_) = B");
+        
+        assert_eq!(Rule::alpha(&r, &r2), None);
+        assert_eq!(Rule::alpha(&r, &r3), None);
+        assert_eq!(Rule::alpha(&r, &r4), None);
+        
+        let mut expected_map = HashMap::default();
+        expected_map.insert(
+            r.clone().variables()[0].clone(),
+            Term::Variable(r5.clone().variables()[0].clone())
+        );
+        
+        assert_eq!(Rule::alpha(&r, &r5), Some(expected_map));
+    }
+
+    #[test]
+    fn substitute_test() {
+        let mut sig = Signature::default();
+        
+        let r = parse_rule(&mut sig, "A(x_ y_) = A(x_) | B(y_)").expect("parse of A(x_ y_) = A(x_) | B(y_)");
+        let c = parse_term(&mut sig, "C").expect("parse of C");
+        let vars = r.variables();
+        let x = vars[0].clone();
+
+        let mut substitution = HashMap::default();
+        substitution.insert(x, c);
+        
+        let r2 = r.substitute(&substitution);
+        
+        assert_eq!(r2.display(), "A(C y_) = A(C) | B(y_)");
+    }
+}

--- a/src/types/signature.rs
+++ b/src/types/signature.rs
@@ -687,17 +687,56 @@ mod tests {
 
     #[test]
     fn new_test() {
-
+        // let mut sig = Signature::new(vec![
+        //    (2, Some(".".to_string())),
+        //    (0, Some("S".to_string())),
+        //    (0, Some("K".to_string())),
+        // ]);
+        // let ops = sig.operators();
+        
+        // let op_names: Vec<String> = ops.iter().map(|op| op.display()).collect();
+        // assert_eq!(op_names, vec![".", "S", "K"]);
+        
+        // let mut sig2 = Signature::default();
+        // let p = sig2.new_op(2, Some(".".to_string()));
+        // let s = sig2.new_op(0, Some("S".to_string()));
+        // let k = sig2.new_op(0, Some("K".to_string()));
+        
+        // assert_eq!(sig, sig2);
+        
+        // let mut sig = Signature::new(vec![]);
+        
+        // let mut sig2 = Signature::default();
+        
+        // assert_eq!(sig, sig2);
     }
 
     #[test]
     fn operators_test() {
-
+        // let mut sig = Signature:: new(vec![
+        //    (2, Some(".".to_string())),
+        //    (0, Some("S".to_string())),
+        //    (0, Some("K".to_string())),
+        // ]);
+        
+        // let ops: Vec<String> = sig.operators().iter().map(|op| op.display()).collect();;
+        
+        // assert_eq!(ops, vec![".", "S", "K"]);
     }
 
     #[test]
     fn variables_test() {
-
+        // let mut sig = Signature:: new(vec![
+        //    (2, Some(".".to_string())),
+        //    (0, Some("S".to_string())),
+        //    (0, Some("K".to_string())),
+        // ]);
+        
+        // parse_term(&mut sig, "A(x_ y_)").expect("parse of A(x_ y_)");
+        
+        // let vars: Vec<String> = sig.variables().iter().map(|v| v.display()).collect();
+        
+        // assert_eq!(vars, vec!["x_", "y_"]);
     }
 
     #[test]
@@ -713,12 +752,25 @@ mod tests {
 
     #[test]
     fn new_op_test() {
-
+        // let mut sig = Signature::default();
+        
+        // let a = sig.new_op(1, Some(".".to_string()));
+        // let s = sig.new_op(2, Some("S".to_string()));
+        // let s2 = sig.new_op(2, Some("S".to_string()));
+        
+        // assert_ne!(a, s);
+        // assert_ne!(a, s2);
+        // assert_ne!(s, s2);
     }
 
     #[test]
     fn new_var() {
-
+        // let mut sig = Signature::default();
+        
+        // let z = sig.new_var(Some("z".to_string()));
+        // let z2 = sig.new_var(Some("z".to_string()));
+        
+        // assert_ne!(z, z2);
     }
 
     #[test]

--- a/src/types/signature.rs
+++ b/src/types/signature.rs
@@ -686,36 +686,40 @@ mod tests {
     use super::*;
 
     #[test]
-    #[ignore]
     fn new_test() {
         let mut sig = Signature::new(vec![
            (2, Some(".".to_string())),
            (0, Some("S".to_string())),
            (0, Some("K".to_string())),
         ]);
-        let ops = sig.operators();
+        let mut ops = sig.operators();
         
-        let op_names: Vec<String> = ops.iter().map(|op| op.display()).collect();
+        let mut op_names: Vec<String> = ops.iter().map(|op| op.display()).collect();
         assert_eq!(op_names, vec![".", "S", "K"]);
         
         let mut sig2 = Signature::default();
-        let p = sig2.new_op(2, Some(".".to_string()));
-        let s = sig2.new_op(0, Some("S".to_string()));
-        let k = sig2.new_op(0, Some("K".to_string()));
+        sig2.new_op(2, Some(".".to_string()));
+        sig2.new_op(0, Some("S".to_string()));
+        sig2.new_op(0, Some("K".to_string()));
+
+        ops = sig2.operators();
+        
+        op_names = ops.iter().map(|op| op.display()).collect();
+        assert_eq!(op_names, vec![".", "S", "K"]);
         
         assert_eq!(sig, sig2);
         
-        let mut sig = Signature::new(vec![]);
+        sig = Signature::new(vec![]);
         
-        let mut sig2 = Signature::default();
-        
+        sig2 = Signature::default();
+
         assert_eq!(sig, sig2);
     }
 
     #[test]
     #[ignore]
     fn operators_test() {
-        let mut sig = Signature:: new(vec![
+        let sig = Signature:: new(vec![
            (2, Some(".".to_string())),
            (0, Some("S".to_string())),
            (0, Some("K".to_string())),

--- a/src/types/signature.rs
+++ b/src/types/signature.rs
@@ -686,57 +686,60 @@ mod tests {
     use super::*;
 
     #[test]
+    #[ignore]
     fn new_test() {
-        // let mut sig = Signature::new(vec![
-        //    (2, Some(".".to_string())),
-        //    (0, Some("S".to_string())),
-        //    (0, Some("K".to_string())),
-        // ]);
-        // let ops = sig.operators();
+        let mut sig = Signature::new(vec![
+           (2, Some(".".to_string())),
+           (0, Some("S".to_string())),
+           (0, Some("K".to_string())),
+        ]);
+        let ops = sig.operators();
         
-        // let op_names: Vec<String> = ops.iter().map(|op| op.display()).collect();
-        // assert_eq!(op_names, vec![".", "S", "K"]);
+        let op_names: Vec<String> = ops.iter().map(|op| op.display()).collect();
+        assert_eq!(op_names, vec![".", "S", "K"]);
         
-        // let mut sig2 = Signature::default();
-        // let p = sig2.new_op(2, Some(".".to_string()));
-        // let s = sig2.new_op(0, Some("S".to_string()));
-        // let k = sig2.new_op(0, Some("K".to_string()));
+        let mut sig2 = Signature::default();
+        let p = sig2.new_op(2, Some(".".to_string()));
+        let s = sig2.new_op(0, Some("S".to_string()));
+        let k = sig2.new_op(0, Some("K".to_string()));
         
-        // assert_eq!(sig, sig2);
+        assert_eq!(sig, sig2);
         
-        // let mut sig = Signature::new(vec![]);
+        let mut sig = Signature::new(vec![]);
         
-        // let mut sig2 = Signature::default();
+        let mut sig2 = Signature::default();
         
-        // assert_eq!(sig, sig2);
+        assert_eq!(sig, sig2);
     }
 
     #[test]
+    #[ignore]
     fn operators_test() {
-        // let mut sig = Signature:: new(vec![
-        //    (2, Some(".".to_string())),
-        //    (0, Some("S".to_string())),
-        //    (0, Some("K".to_string())),
-        // ]);
+        let mut sig = Signature:: new(vec![
+           (2, Some(".".to_string())),
+           (0, Some("S".to_string())),
+           (0, Some("K".to_string())),
+        ]);
         
-        // let ops: Vec<String> = sig.operators().iter().map(|op| op.display()).collect();;
+        let ops: Vec<String> = sig.operators().iter().map(|op| op.display()).collect();;
         
-        // assert_eq!(ops, vec![".", "S", "K"]);
+        assert_eq!(ops, vec![".", "S", "K"]);
     }
 
     #[test]
+    #[ignore]
     fn variables_test() {
-        // let mut sig = Signature:: new(vec![
-        //    (2, Some(".".to_string())),
-        //    (0, Some("S".to_string())),
-        //    (0, Some("K".to_string())),
-        // ]);
+        let mut sig = Signature:: new(vec![
+           (2, Some(".".to_string())),
+           (0, Some("S".to_string())),
+           (0, Some("K".to_string())),
+        ]);
         
-        // parse_term(&mut sig, "A(x_ y_)").expect("parse of A(x_ y_)");
+        parse_term(&mut sig, "A(x_ y_)").expect("parse of A(x_ y_)");
         
-        // let vars: Vec<String> = sig.variables().iter().map(|v| v.display()).collect();
+        let vars: Vec<String> = sig.variables().iter().map(|v| v.display()).collect();
         
-        // assert_eq!(vars, vec!["x_", "y_"]);
+        assert_eq!(vars, vec!["x_", "y_"]);
     }
 
     #[test]
@@ -751,26 +754,28 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn new_op_test() {
-        // let mut sig = Signature::default();
+        let mut sig = Signature::default();
         
-        // let a = sig.new_op(1, Some(".".to_string()));
-        // let s = sig.new_op(2, Some("S".to_string()));
-        // let s2 = sig.new_op(2, Some("S".to_string()));
+        let a = sig.new_op(1, Some(".".to_string()));
+        let s = sig.new_op(2, Some("S".to_string()));
+        let s2 = sig.new_op(2, Some("S".to_string()));
         
-        // assert_ne!(a, s);
-        // assert_ne!(a, s2);
-        // assert_ne!(s, s2);
+        assert_ne!(a, s);
+        assert_ne!(a, s2);
+        assert_ne!(s, s2);
     }
 
     #[test]
+    #[ignore]
     fn new_var() {
-        // let mut sig = Signature::default();
+        let mut sig = Signature::default();
         
-        // let z = sig.new_var(Some("z".to_string()));
-        // let z2 = sig.new_var(Some("z".to_string()));
+        let z = sig.new_var(Some("z".to_string()));
+        let z2 = sig.new_var(Some("z".to_string()));
         
-        // assert_ne!(z, z2);
+        assert_ne!(z, z2);
     }
 
     #[test]

--- a/src/types/term.rs
+++ b/src/types/term.rs
@@ -1164,15 +1164,15 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn context_variables_test() {
-    //     let mut sig = Signature::default();
+        let mut sig = Signature::default();
     
-    //     let context = parse_context(&mut sig, "A([!]) B y_ z_").expect("parse of A([!]) B y_ z_");
+        let context = parse_context(&mut sig, "A([!]) B y_ z_").expect("parse of A([!]) B y_ z_");
         
-    //     let var_names: Vec<String> = context.variables().iter().map(|v| v.display()).collect();
+        let var_names: Vec<String> = context.variables().iter().map(|v| v.display()).collect();
         
-    //     assert_eq!(var_names, vec!["y_".to_string(), "z_".to_string()]);
-    // 
+        assert_eq!(var_names, vec!["y_".to_string(), "z_".to_string()]);
     }
 
     #[test]
@@ -1296,13 +1296,14 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn term_display_test() {
-    //     let mut sig = Signature::default();
+        let mut sig = Signature::default();
         
-    //     let term = parse_term(&mut sig, "A B(x_) CONS(SUCC(SUCC(ZERO)) CONS(SUCC(ZERO) CONS(ZERO NIL))) DECC(DECC(DIGIT(1) 0) 5)")
-    //          .expect("parse of A B(x_) CONS(SUCC(SUCC(ZERO)) CONS(SUCC(ZERO) CONS(ZERO NIL))) DECC(DECC(DIGIT(1) 0) 5)");
+        let term = parse_term(&mut sig, "A B(x_) CONS(SUCC(SUCC(ZERO)) CONS(SUCC(ZERO) CONS(ZERO NIL))) DECC(DECC(DIGIT(1) 0) 5)")
+            .expect("parse of A B(x_) CONS(SUCC(SUCC(ZERO)) CONS(SUCC(ZERO) CONS(ZERO NIL))) DECC(DECC(DIGIT(1) 0) 5)");
         
-    //     assert_eq!(term.display(), ".(.(.(A B(x_)) CONS(SUCC(SUCC(ZERO)) CONS(SUCC(ZERO) CONS(ZERO NIL)))) DECC(DECC(DIGIT(1) 0) 5))");
+        assert_eq!(term.display(), ".(.(.(A B(x_)) CONS(SUCC(SUCC(ZERO)) CONS(SUCC(ZERO) CONS(ZERO NIL)))) DECC(DECC(DIGIT(1) 0) 5))");
     }
 
     #[test]
@@ -1464,6 +1465,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn constraint_substitute_test() {
 
     }

--- a/src/types/term.rs
+++ b/src/types/term.rs
@@ -1163,8 +1163,8 @@ mod tests {
         assert_eq!(atoms, vec!["x_", "B", "A"]);
     }
 
-    // #[test]
-    // fn context_variables_test() {
+    #[test]
+    fn context_variables_test() {
     //     let mut sig = Signature::default();
     
     //     let context = parse_context(&mut sig, "A([!]) B y_ z_").expect("parse of A([!]) B y_ z_");
@@ -1173,7 +1173,7 @@ mod tests {
         
     //     assert_eq!(var_names, vec!["y_".to_string(), "z_".to_string()]);
     // 
-    // }
+    }
 
     #[test]
     fn context_operators_test() {
@@ -1295,15 +1295,15 @@ mod tests {
         assert_eq!(term.display(), "A(B C)"); 
     }
 
-    // #[test]
-    // fn term_display_test() {
+    #[test]
+    fn term_display_test() {
     //     let mut sig = Signature::default();
         
     //     let term = parse_term(&mut sig, "A B(x_) CONS(SUCC(SUCC(ZERO)) CONS(SUCC(ZERO) CONS(ZERO NIL))) DECC(DECC(DIGIT(1) 0) 5)")
     //          .expect("parse of A B(x_) CONS(SUCC(SUCC(ZERO)) CONS(SUCC(ZERO) CONS(ZERO NIL))) DECC(DECC(DIGIT(1) 0) 5)");
         
     //     assert_eq!(term.display(), ".(.(.(A B(x_)) CONS(SUCC(SUCC(ZERO)) CONS(SUCC(ZERO) CONS(ZERO NIL)))) DECC(DECC(DIGIT(1) 0) 5))");
-    // }
+    }
 
     #[test]
     fn term_pretty_test() {

--- a/src/types/term.rs
+++ b/src/types/term.rs
@@ -1203,9 +1203,15 @@ mod tests {
     fn context_head_test() {
         let mut sig = Signature::default();
         
-        let context = parse_context(&mut sig, "A(B([!]) z_)").expect("parse of A(B([!]) z_)");
+        let mut context = parse_context(&mut sig, "A(B([!]) z_)").expect("parse of A(B([!]) z_)");
         
         assert_eq!(context.head().unwrap().display(), "A");
+
+        sig = Signature::default();
+
+        context = parse_context(&mut sig, "z_").expect("parse of z_");
+
+        assert_eq!(context.head().unwrap().display(), "z_"); 
     }
 
     #[test]

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -462,3 +462,5 @@ K x_ y_ = x_;
 BAZ(FOO, BAR(x_)) = BAZ(x_, FOO) | SUCC(x_);"
     );
 }
+
+


### PR DESCRIPTION
tests for functions that were already covered are ignored.